### PR TITLE
1-Day SIMM

### DIFF
--- a/simm-ple/src/main/java/com/acadiasoft/im/simmple/engine/Simmple.java
+++ b/simm-ple/src/main/java/com/acadiasoft/im/simmple/engine/Simmple.java
@@ -26,6 +26,7 @@ import com.acadiasoft.im.base.fx.FxConverter;
 import com.acadiasoft.im.base.imtree.ImTree;
 import com.acadiasoft.im.base.imtree.TotalMargin;
 import com.acadiasoft.im.schedule.models.utils.ScheduleCalculationType;
+import com.acadiasoft.im.simm.model.param.HoldingPeriod;
 import com.acadiasoft.im.simm.model.utils.SimmCalculationType;
 import com.acadiasoft.im.simmple.model.imtree.BlankImTree;
 import com.acadiasoft.im.simmple.model.Crif;
@@ -50,14 +51,14 @@ public class Simmple extends SimmpleForRegulator {
 
   // NOTE: post regulator applies to the pledgor, collect regulator applies to the secured
 
-  public static ImTreeResult calculateWorstOf(List<Crif> crifs, String calculationCurrency, FxConverter fx, String resultCurrency, ImRole role, SimmCalculationType simmType, ScheduleCalculationType scheduleType, Optional<BigDecimal> netGrossRate) {
+  public static ImTreeResult calculateWorstOf(List<Crif> crifs, String calculationCurrency, FxConverter fx, String resultCurrency, ImRole role, SimmCalculationType simmType, ScheduleCalculationType scheduleType, Optional<BigDecimal> netGrossRate, HoldingPeriod holdingPeriod) {
     Function<String, ImTreeResult> convert= reg -> {
       // These methods both return trees at the model level, we need to have them in the same function so we calculate
       //  the total margin of SIMM plus Schedule for the same regulator.
       // If we move these into two separate calls a different regulator could be worse for either individual model
       //  which would result in an incorrect overall worst of amount when everything is summed
       ImTree schedule = calculateScheduleForRegulator(crifs, fx, resultCurrency, role, reg, scheduleType, netGrossRate).getImTree();
-      ImTree simm = calculateSimmForRegulator(crifs, calculationCurrency, fx, resultCurrency, role, reg, simmType).getImTree();
+      ImTree simm = calculateSimmForRegulator(crifs, calculationCurrency, fx, resultCurrency, role, reg, simmType, holdingPeriod).getImTree();
       return new ImTreeResult(TotalMargin.build(simm, schedule), reg, resultCurrency);
     };
 
@@ -71,8 +72,8 @@ public class Simmple extends SimmpleForRegulator {
     return new ImTreeResult(TotalMargin.build(treeResult.getImTree()), treeResult.getRegulator(), treeResult.getCurrency());
   }
 
-  public static ImTreeResult calculateSimmWorstOf(List<Crif> crifs, String calculationCurrency, FxConverter fx, String resultCurrency, ImRole role, SimmCalculationType simmType) {
-    Function<String, ImTreeResult> convert = reg -> calculateSimmForRegulator(crifs, calculationCurrency, fx, resultCurrency, role, reg, simmType);
+  public static ImTreeResult calculateSimmWorstOf(List<Crif> crifs, String calculationCurrency, FxConverter fx, String resultCurrency, ImRole role, SimmCalculationType simmType, HoldingPeriod holdingPeriod) {
+    Function<String, ImTreeResult> convert = reg -> calculateSimmForRegulator(crifs, calculationCurrency, fx, resultCurrency, role, reg, simmType, holdingPeriod);
     ImTreeResult treeResult = worstOf(crifs, role, convert, resultCurrency);
     return new ImTreeResult(TotalMargin.build(treeResult.getImTree()), treeResult.getRegulator(), treeResult.getCurrency());
   }

--- a/simm-ple/src/main/java/com/acadiasoft/im/simmple/engine/SimmpleForRegulator.java
+++ b/simm-ple/src/main/java/com/acadiasoft/im/simmple/engine/SimmpleForRegulator.java
@@ -31,6 +31,7 @@ import com.acadiasoft.im.schedule.models.SchedulePv;
 import com.acadiasoft.im.schedule.models.utils.ScheduleCalculationType;
 import com.acadiasoft.im.simm.engine.Simm;
 import com.acadiasoft.im.simm.model.*;
+import com.acadiasoft.im.simm.model.param.HoldingPeriod;
 import com.acadiasoft.im.simm.model.utils.SimmCalculationType;
 import com.acadiasoft.im.simmple.model.Crif;
 import com.acadiasoft.im.simmple.model.ImRole;
@@ -55,9 +56,10 @@ public class SimmpleForRegulator {
    * @param role the role that calculation is being run for
    * @param regulator the regulator we are calculating for
    * @param type the type of SIMM calculation being run
+   * @param holdingPeriod
    * @return an ImTree at the model level with the model set to SIMM
    */
-  public static ImTreeResult calculateSimmForRegulator(List<Crif> crifs, String calculationCurrency, FxConverter fx, String resultCurrency, ImRole role, String regulator, SimmCalculationType type) {
+  public static ImTreeResult calculateSimmForRegulator(List<Crif> crifs, String calculationCurrency, FxConverter fx, String resultCurrency, ImRole role, String regulator, SimmCalculationType type, HoldingPeriod holdingPeriod) {
     // get all of the crif which are in the SIMM model class with the applied regualtor
     List<Crif> filteredForSimmAndRegulator = crifs.stream().filter(isSimm).filter(c -> containsRegulator(role, c, regulator)).collect(Collectors.toList());
     // get all of the add on type crif records and convert them to their SIMM equivalent
@@ -70,7 +72,7 @@ public class SimmpleForRegulator {
     List<Crif> filteredForSensitivity = filteredForSimmAndRegulator.stream().filter(isSensitivityType).collect(Collectors.toList());
     List<Sensitivity> sensitivities = filteredForSensitivity.stream().map(c -> SimmpleConversions.convertToSensitivity(c, fx, role)).collect(Collectors.toList());
     // recalculate tree in the result currency and set the sign so that pledgor negative
-    return new ImTreeResult(ConversionImTree.convert(role, Simm.calculate(sensitivities, multipliers, factors, notionals, fixed, calculationCurrency, type), fx, FxRate.USD, resultCurrency), regulator, resultCurrency);
+    return new ImTreeResult(ConversionImTree.convert(role, Simm.calculate(sensitivities, multipliers, factors, notionals, fixed, calculationCurrency, type, holdingPeriod), fx, FxRate.USD, resultCurrency), regulator, resultCurrency);
   }
 
   /**

--- a/simm-ple/src/main/java/com/acadiasoft/im/simmple/engine/SimmpleForRegulator.java
+++ b/simm-ple/src/main/java/com/acadiasoft/im/simmple/engine/SimmpleForRegulator.java
@@ -67,7 +67,7 @@ public class SimmpleForRegulator {
     List<ProductMultiplier> multipliers = filteredForAddOnType.stream().filter(isProductMultiplier).map(SimmpleConversions::convertToMultiplier).collect(Collectors.toList());
     List<AddOnNotionalFactor> factors = filteredForAddOnType.stream().filter(isNotionalFactor).map(SimmpleConversions::convertToFactor).collect(Collectors.toList());
     List<AddOnNotional> notionals = filteredForAddOnType.stream().filter(isSimmNotional).map(c -> SimmpleConversions.convertToSimmNotional(c, fx)).collect(Collectors.toList());
-    List<AddOnFixedAmount> fixed = filteredForAddOnType.stream().filter(isFixedAmount).map(c -> SimmpleConversions.convertToFixed(c, fx)).collect(Collectors.toList());
+    List<AddOnFixedAmount> fixed = filteredForAddOnType.stream().filter(isFixedAmount).map(c -> SimmpleConversions.convertToFixed(c, fx, holdingPeriod)).collect(Collectors.toList());
     // get all of the regular sensitivities from crif and convert them
     List<Crif> filteredForSensitivity = filteredForSimmAndRegulator.stream().filter(isSensitivityType).collect(Collectors.toList());
     List<Sensitivity> sensitivities = filteredForSensitivity.stream().map(c -> SimmpleConversions.convertToSensitivity(c, fx, role)).collect(Collectors.toList());
@@ -86,7 +86,7 @@ public class SimmpleForRegulator {
    * @return an ImTree at the model level with the model set to Schedule
    */
   public static ImTreeResult calculateScheduleForRegulator(List<Crif> crifs, FxConverter fx, String resultCurrency, ImRole role, String regulator, ScheduleCalculationType type, Optional<BigDecimal> netGrossRate) {
-    // get all of the crif which are in the SCHEDLE model and have the applied regulator
+    // get all of the crif which are in the SCHEDULE model and have the applied regulator
     List<Crif> filteredForSimmAndRegulator = crifs.stream().filter(isSchedule).filter(c -> containsRegulator(role, c, regulator)).collect(Collectors.toList());
     // convert the CRIF objects to the schedule module's types
     List<ScheduleNotional> notionals = filteredForSimmAndRegulator.stream().filter(isScheduleNotional).map(c -> SimmpleConversions.convertToScheduleNotional(c, fx)).collect(Collectors.toList());

--- a/simm-ple/src/main/java/com/acadiasoft/im/simmple/model/utils/SimmpleConversions.java
+++ b/simm-ple/src/main/java/com/acadiasoft/im/simmple/model/utils/SimmpleConversions.java
@@ -24,15 +24,19 @@ package com.acadiasoft.im.simmple.model.utils;
 
 import com.acadiasoft.im.base.fx.FxConverter;
 import com.acadiasoft.im.base.fx.FxRate;
+import com.acadiasoft.im.base.util.BigDecimalUtils;
 import com.acadiasoft.im.schedule.models.ScheduleNotional;
 import com.acadiasoft.im.schedule.models.SchedulePv;
 import com.acadiasoft.im.simm.model.*;
+import com.acadiasoft.im.simm.model.param.HoldingPeriod;
 import com.acadiasoft.im.simmple.model.Crif;
 import com.acadiasoft.im.simmple.model.ImRole;
 
 import java.math.BigDecimal;
 
 public class SimmpleConversions {
+
+  static final BigDecimal SQRT10 = BigDecimalUtils.sqrt(BigDecimal.TEN);
 
   public static Sensitivity convertToSensitivity(Crif crif, FxConverter fx, ImRole role) {
     BigDecimal amountUSD = getCrifAmountUsd(crif, fx);
@@ -52,8 +56,9 @@ public class SimmpleConversions {
     return new AddOnNotional(crif.getQualifier(), getCrifAmountUsd(crif, fx));
   }
 
-  public static AddOnFixedAmount convertToFixed(Crif crif, FxConverter fx) {
-    return new AddOnFixedAmount(getCrifAmountUsd(crif, fx));
+  public static AddOnFixedAmount convertToFixed(Crif crif, FxConverter fx, HoldingPeriod holdingPeriod) {
+    return new AddOnFixedAmount(getCrifAmountUsd(crif, fx)
+            .divide(holdingPeriod == HoldingPeriod.TenDay ? BigDecimal.ONE : SQRT10));
   }
 
   public static ScheduleNotional convertToScheduleNotional(Crif crif, FxConverter fx) {

--- a/simm-ple/src/test/java/com/acadiasoft/im/simmple/CalculationCurrencyTest.java
+++ b/simm-ple/src/test/java/com/acadiasoft/im/simmple/CalculationCurrencyTest.java
@@ -26,6 +26,7 @@ import com.acadiasoft.im.base.fx.FxConverter;
 import com.acadiasoft.im.base.fx.FxRate;
 import com.acadiasoft.im.base.fx.NoConversionFxRate;
 import com.acadiasoft.im.simm.engine.Simm;
+import com.acadiasoft.im.simm.model.param.HoldingPeriod;
 import com.acadiasoft.im.simm.model.utils.SimmCalculationType;
 import com.acadiasoft.im.simmple.engine.Simmple;
 import com.acadiasoft.im.simmple.model.Crif;
@@ -50,8 +51,8 @@ public class CalculationCurrencyTest {
   public void testCalculationCurrencyBasic() {
     Crif one = new Crif("1a","2018-02-01", "2019-02-01", null, null, "SIMM-P", "RatesFX", "Risk_FX", "USD", "", "", "","1000.00","USD","1000.00", "CFTC", "CFTC");
     Crif two = new Crif("1b","2018-02-01", "2019-02-01", null, null,"SIMM-P", "RatesFX", "Risk_FX", "EUR", "", "", "","5000.00","USD","5000.00", "CFTC", "CFTC");
-    BigDecimal simmLibAmount = Simm.calculateStandard(Arrays.asList(SimmpleConversions.convertToSensitivity(one, fx, ImRole.PLEDGOR)), "GBP").negate();
-    ImTreeResult simmpleAmount = Simmple.calculateSimmWorstOf(Arrays.asList(one, two), "EUR", fx, FxRate.USD, ImRole.PLEDGOR, SimmCalculationType.STANDARD);
+    BigDecimal simmLibAmount = Simm.calculateStandard(Arrays.asList(SimmpleConversions.convertToSensitivity(one, fx, ImRole.PLEDGOR)), "GBP", HoldingPeriod.TenDay).negate();
+    ImTreeResult simmpleAmount = Simmple.calculateSimmWorstOf(Arrays.asList(one, two), "EUR", fx, FxRate.USD, ImRole.PLEDGOR, SimmCalculationType.STANDARD, HoldingPeriod.TenDay);
     Assert.assertEquals(simmLibAmount, simmpleAmount.getImTree().getMargin());
   }
 

--- a/simm-ple/src/test/java/com/acadiasoft/im/simmple/WorstOfTest.java
+++ b/simm-ple/src/test/java/com/acadiasoft/im/simmple/WorstOfTest.java
@@ -25,18 +25,16 @@ package com.acadiasoft.im.simmple;
 import com.acadiasoft.im.base.fx.FxConverter;
 import com.acadiasoft.im.base.fx.NoConversionFxRate;
 import com.acadiasoft.im.simm.engine.Simm;
+import com.acadiasoft.im.simm.model.param.HoldingPeriod;
 import com.acadiasoft.im.simm.model.utils.SimmCalculationType;
 import com.acadiasoft.im.simmple.engine.Simmple;
 import com.acadiasoft.im.simmple.model.Crif;
 import com.acadiasoft.im.simmple.model.ImRole;
-import com.acadiasoft.im.simmple.model.result.ImResult;
 import com.acadiasoft.im.simmple.model.result.ImTreeResult;
 import com.acadiasoft.im.simmple.model.utils.SimmpleConversions;
-import com.acadiasoft.im.simmple.model.utils.SimmpleUtils;
 import org.junit.Assert;
 import org.junit.Test;
 
-import javax.management.relation.Role;
 import java.math.BigDecimal;
 import java.util.Arrays;
 
@@ -53,8 +51,8 @@ public class WorstOfTest {
     Crif one = new Crif("1", "2018-02-01", "2019-02-01", null, null, "SIMM-P", "RatesFX", "Risk_FX", "EUR", "", "", "", "1000.00", "USD", "1000.00", "included", "");
     Crif two = new Crif("2", "2018-02-01", "2019-02-01", null, null, "SIMM-P", "RatesFX", "Risk_FX", "EUR", "", "", "", "1000.00", "USD", "1000.00", "", "included");
 
-    BigDecimal amountPost = Simm.calculateStandard(Arrays.asList(SimmpleConversions.convertToSensitivity(one, fx, ImRole.PLEDGOR), SimmpleConversions.convertToSensitivity(two, fx, ImRole.PLEDGOR)), "USD");
-    ImTreeResult post = Simmple.calculateSimmWorstOf(Arrays.asList(one, two),"USD", fx, "USD", ImRole.PLEDGOR, SimmCalculationType.STANDARD);
+    BigDecimal amountPost = Simm.calculateStandard(Arrays.asList(SimmpleConversions.convertToSensitivity(one, fx, ImRole.PLEDGOR), SimmpleConversions.convertToSensitivity(two, fx, ImRole.PLEDGOR)), "USD", HoldingPeriod.TenDay);
+    ImTreeResult post = Simmple.calculateSimmWorstOf(Arrays.asList(one, two),"USD", fx, "USD", ImRole.PLEDGOR, SimmCalculationType.STANDARD, HoldingPeriod.TenDay);
     Assert.assertEquals(amountPost.negate(), post.getImTree().getMargin());
     Assert.assertEquals("included", post.getRegulator());
     Assert.assertEquals("USD", post.getCurrency());
@@ -65,13 +63,13 @@ public class WorstOfTest {
     Crif one = new Crif("1","2018-02-01", "2019-02-01", null, null,"SIMM-P", "RatesFX", "Risk_FX", "EUR", "", "", "", "1000.00", "USD", "1000.00", "CFTC,SEC", "");
     Crif two = new Crif("2","2018-02-01", "2019-02-01", null, null,"SIMM-P", "RatesFX", "Risk_FX", "GBP", "", "", "", "5000.00", "USD", "5000.00", "CFTC,SEC", "");
 
-    BigDecimal amountPost = Simm.calculateStandard(Arrays.asList(SimmpleConversions.convertToSensitivity(one, fx, ImRole.PLEDGOR), SimmpleConversions.convertToSensitivity(two, fx, ImRole.PLEDGOR)), "USD");
-    ImTreeResult post = Simmple.calculateSimmWorstOf(Arrays.asList(one, two),"USD", fx, "USD", ImRole.PLEDGOR, SimmCalculationType.STANDARD);
+    BigDecimal amountPost = Simm.calculateStandard(Arrays.asList(SimmpleConversions.convertToSensitivity(one, fx, ImRole.PLEDGOR), SimmpleConversions.convertToSensitivity(two, fx, ImRole.PLEDGOR)), "USD", HoldingPeriod.TenDay);
+    ImTreeResult post = Simmple.calculateSimmWorstOf(Arrays.asList(one, two),"USD", fx, "USD", ImRole.PLEDGOR, SimmCalculationType.STANDARD, HoldingPeriod.TenDay);
     Assert.assertEquals(amountPost.negate(), post.getImTree().getMargin());
     Assert.assertEquals("CFTC", post.getRegulator());
     Assert.assertEquals("USD", post.getCurrency());
 
-    ImTreeResult collect = Simmple.calculateSimmWorstOf(Arrays.asList(one, two),"USD", fx, "USD", ImRole.SECURED, SimmCalculationType.STANDARD);
+    ImTreeResult collect = Simmple.calculateSimmWorstOf(Arrays.asList(one, two),"USD", fx, "USD", ImRole.SECURED, SimmCalculationType.STANDARD, HoldingPeriod.TenDay);
     Assert.assertEquals(BigDecimal.ZERO, collect.getImTree().getMargin());
     Assert.assertEquals("", collect.getRegulator());
     Assert.assertEquals("USD", collect.getCurrency());
@@ -82,13 +80,13 @@ public class WorstOfTest {
     Crif one = new Crif("1","2018-02-01", "2019-02-01", null, null,"SIMM-P", "RatesFX", "Risk_FX", "EUR", "", "", "", "1000.00", "USD", "1000.00", "SEC,CFTC", "");
     Crif two = new Crif("2","2018-02-01", "2019-02-01", null, null,"SIMM-P", "RatesFX", "Risk_FX", "GBP", "", "", "", "5000.00", "USD", "5000.00", "SEC,CFTC", "");
 
-    BigDecimal amountPost = Simm.calculateStandard(Arrays.asList(SimmpleConversions.convertToSensitivity(one, fx, ImRole.PLEDGOR), SimmpleConversions.convertToSensitivity(two, fx, ImRole.PLEDGOR)), "USD");
-    ImTreeResult post = Simmple.calculateSimmWorstOf(Arrays.asList(one, two),"USD", fx, "USD", ImRole.PLEDGOR, SimmCalculationType.STANDARD);
+    BigDecimal amountPost = Simm.calculateStandard(Arrays.asList(SimmpleConversions.convertToSensitivity(one, fx, ImRole.PLEDGOR), SimmpleConversions.convertToSensitivity(two, fx, ImRole.PLEDGOR)), "USD", HoldingPeriod.TenDay);
+    ImTreeResult post = Simmple.calculateSimmWorstOf(Arrays.asList(one, two),"USD", fx, "USD", ImRole.PLEDGOR, SimmCalculationType.STANDARD, HoldingPeriod.TenDay);
     Assert.assertEquals(amountPost.negate(), post.getImTree().getMargin());
     Assert.assertEquals("CFTC", post.getRegulator());
     Assert.assertEquals("USD", post.getCurrency());
 
-    ImTreeResult collect = Simmple.calculateSimmWorstOf(Arrays.asList(one, two),"USD", fx, "USD", ImRole.SECURED, SimmCalculationType.STANDARD);
+    ImTreeResult collect = Simmple.calculateSimmWorstOf(Arrays.asList(one, two),"USD", fx, "USD", ImRole.SECURED, SimmCalculationType.STANDARD, HoldingPeriod.TenDay);
     Assert.assertEquals(BigDecimal.ZERO, collect.getImTree().getMargin());
     Assert.assertEquals("", collect.getRegulator());
     Assert.assertEquals("USD", collect.getCurrency());
@@ -99,8 +97,8 @@ public class WorstOfTest {
     Crif one = new Crif("1","2018-02-01", "2019-02-01", null, null,"SIMM-P", "RatesFX", "Risk_FX", "EUR", "", "", "", "1000.00", "USD", "1000.00", "CFTC", "" );
     Crif two = new Crif("2","2018-02-01", "2019-02-01", null, null,"SIMM-P", "RatesFX", "Risk_FX", "GBP", "", "", "", "5000.00", "USD", "5000.00", "SEC,CFTC", "");
 
-    BigDecimal amountPost = Simm.calculateStandard(Arrays.asList(SimmpleConversions.convertToSensitivity(one, fx, ImRole.PLEDGOR), SimmpleConversions.convertToSensitivity(two, fx, ImRole.PLEDGOR)), "USD");
-    ImTreeResult post = Simmple.calculateSimmWorstOf(Arrays.asList(one, two),"USD", fx, "USD", ImRole.PLEDGOR, SimmCalculationType.STANDARD);
+    BigDecimal amountPost = Simm.calculateStandard(Arrays.asList(SimmpleConversions.convertToSensitivity(one, fx, ImRole.PLEDGOR), SimmpleConversions.convertToSensitivity(two, fx, ImRole.PLEDGOR)), "USD", HoldingPeriod.TenDay);
+    ImTreeResult post = Simmple.calculateSimmWorstOf(Arrays.asList(one, two),"USD", fx, "USD", ImRole.PLEDGOR, SimmCalculationType.STANDARD, HoldingPeriod.TenDay);
     Assert.assertEquals(amountPost.negate(), post.getImTree().getMargin());
     Assert.assertEquals("CFTC", post.getRegulator());
     Assert.assertEquals("USD", post.getCurrency());

--- a/simm/src/main/java/com/acadiasoft/im/simm/engine/Simm.java
+++ b/simm/src/main/java/com/acadiasoft/im/simm/engine/Simm.java
@@ -27,6 +27,7 @@ import com.acadiasoft.im.base.imtree.TotalMargin;
 import com.acadiasoft.im.simm.engine.margin.SimmMargin;
 import com.acadiasoft.im.simm.model.*;
 import com.acadiasoft.im.simm.model.imtree.identifiers.ProductClass;
+import com.acadiasoft.im.simm.model.param.HoldingPeriod;
 import com.acadiasoft.im.simm.model.utils.SensitivityUtils;
 import com.acadiasoft.im.simm.model.utils.SimmCalculationType;
 
@@ -40,40 +41,40 @@ import java.util.Map;
  */
 public class Simm {
 
-  public static BigDecimal calculateStandard(List<Sensitivity> inputSensitivities, String calculationCurrency) {
-    return calculate(inputSensitivities, new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), calculationCurrency, SimmCalculationType.STANDARD).getMargin();
+  public static BigDecimal calculateStandard(List<Sensitivity> inputSensitivities, String calculationCurrency, HoldingPeriod holdingPeriod) {
+    return calculate(inputSensitivities, new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), calculationCurrency, SimmCalculationType.STANDARD, holdingPeriod).getMargin();
   }
 
-  public static BigDecimal calculateAdditional(List<Sensitivity> inputSensitivities, List<ProductMultiplier> multipliers, List<AddOnNotionalFactor> factors, List<AddOnNotional> notionals, List<AddOnFixedAmount> fixed, String calculationCurrency) {
-    return calculate(inputSensitivities, multipliers, factors, notionals, fixed, calculationCurrency, SimmCalculationType.ADDITIONAL).getMargin();
+  public static BigDecimal calculateAdditional(List<Sensitivity> inputSensitivities, List<ProductMultiplier> multipliers, List<AddOnNotionalFactor> factors, List<AddOnNotional> notionals, List<AddOnFixedAmount> fixed, String calculationCurrency, HoldingPeriod holdingPeriod) {
+    return calculate(inputSensitivities, multipliers, factors, notionals, fixed, calculationCurrency, SimmCalculationType.ADDITIONAL, holdingPeriod).getMargin();
   }
 
-  public static BigDecimal calculateTotal(List<Sensitivity> inputSensitivities, List<ProductMultiplier> multipliers, List<AddOnNotionalFactor> factors, List<AddOnNotional> notionals, List<AddOnFixedAmount> fixed, String calculationCurrency) {
-    return calculate(inputSensitivities, multipliers, factors, notionals, fixed, calculationCurrency, SimmCalculationType.TOTAL).getMargin();
+  public static BigDecimal calculateTotal(List<Sensitivity> inputSensitivities, List<ProductMultiplier> multipliers, List<AddOnNotionalFactor> factors, List<AddOnNotional> notionals, List<AddOnFixedAmount> fixed, String calculationCurrency, HoldingPeriod holdingPeriod) {
+    return calculate(inputSensitivities, multipliers, factors, notionals, fixed, calculationCurrency, SimmCalculationType.TOTAL, holdingPeriod).getMargin();
   }
 
-  public static ImTree calculateTreeStandard(List<Sensitivity> inputSensitivities, String calculationCurrency) {
-    return TotalMargin.build(calculate(inputSensitivities, new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), calculationCurrency, SimmCalculationType.STANDARD));
+  public static ImTree calculateTreeStandard(List<Sensitivity> inputSensitivities, String calculationCurrency, HoldingPeriod holdingPeriod) {
+    return TotalMargin.build(calculate(inputSensitivities, new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), calculationCurrency, SimmCalculationType.STANDARD, holdingPeriod));
   }
 
-  public static ImTree calculateTreeAdditional(List<Sensitivity> inputSensitivities, List<ProductMultiplier> multipliers, List<AddOnNotionalFactor> factors, List<AddOnNotional> notionals, List<AddOnFixedAmount> fixed, String calculationCurrency) {
-    return TotalMargin.build(calculate(inputSensitivities, multipliers, factors, notionals, fixed, calculationCurrency, SimmCalculationType.ADDITIONAL));
+  public static ImTree calculateTreeAdditional(List<Sensitivity> inputSensitivities, List<ProductMultiplier> multipliers, List<AddOnNotionalFactor> factors, List<AddOnNotional> notionals, List<AddOnFixedAmount> fixed, String calculationCurrency, HoldingPeriod holdingPeriod) {
+    return TotalMargin.build(calculate(inputSensitivities, multipliers, factors, notionals, fixed, calculationCurrency, SimmCalculationType.ADDITIONAL, holdingPeriod));
   }
 
-  public static ImTree calculateTreeTotal(List<Sensitivity> inputSensitivities, List<ProductMultiplier> multipliers, List<AddOnNotionalFactor> factors, List<AddOnNotional> notionals, List<AddOnFixedAmount> fixed, String calculationCurrency) {
-    return TotalMargin.build(calculate(inputSensitivities, multipliers, factors, notionals, fixed, calculationCurrency, SimmCalculationType.TOTAL));
+  public static ImTree calculateTreeTotal(List<Sensitivity> inputSensitivities, List<ProductMultiplier> multipliers, List<AddOnNotionalFactor> factors, List<AddOnNotional> notionals, List<AddOnFixedAmount> fixed, String calculationCurrency, HoldingPeriod holdingPeriod) {
+    return TotalMargin.build(calculate(inputSensitivities, multipliers, factors, notionals, fixed, calculationCurrency, SimmCalculationType.TOTAL, holdingPeriod));
   }
 
-  public static ImTree calculate(List<Sensitivity> inputSensitivities, List<ProductMultiplier> multipliers, List<AddOnNotionalFactor> factors, List<AddOnNotional> notionals, List<AddOnFixedAmount> fixed, String calculationCurrency, SimmCalculationType type) {
+  public static ImTree calculate(List<Sensitivity> inputSensitivities, List<ProductMultiplier> multipliers, List<AddOnNotionalFactor> factors, List<AddOnNotional> notionals, List<AddOnFixedAmount> fixed, String calculationCurrency, SimmCalculationType type, HoldingPeriod holdingPeriod) {
     List<Sensitivity> filtered = SensitivityUtils.filterDeltaFxRiskInCalcCurrency(inputSensitivities, calculationCurrency);
-    if (type.equals(SimmCalculationType.STANDARD)) return SimmMargin.calculateStandard(filtered);
+    if (type.equals(SimmCalculationType.STANDARD)) return SimmMargin.calculateStandard(filtered, holdingPeriod);
     Map<ProductClass, ProductMultiplier> multiplierMap = SensitivityUtils.groupByThenTakeFirst(multipliers, ProductMultiplier::getProductClass);
     Map<String, AddOnNotionalFactor> factorMap = SensitivityUtils.groupByThenTakeFirst(factors, AddOnNotionalFactor::getProduct);
     Map<String, List<AddOnNotional>> notionalMap = SensitivityUtils.groupBy(notionals, AddOnNotional::getProduct);
     if (type.equals(SimmCalculationType.ADDITIONAL)) {
-      return SimmMargin.calculateAdditional(filtered, multiplierMap, factorMap, notionalMap, fixed);
+      return SimmMargin.calculateAdditional(filtered, multiplierMap, factorMap, notionalMap, fixed, holdingPeriod);
     } else if (type.equals(SimmCalculationType.TOTAL)) {
-      return SimmMargin.calculateTotal(filtered, multiplierMap, factorMap, notionalMap, fixed);
+      return SimmMargin.calculateTotal(filtered, multiplierMap, factorMap, notionalMap, fixed, holdingPeriod);
     } else {
       throw new RuntimeException("Called a SIMM calculation with unknown type: [" + type + "]");
     }

--- a/simm/src/main/java/com/acadiasoft/im/simm/engine/margin/ProductMargin.java
+++ b/simm/src/main/java/com/acadiasoft/im/simm/engine/margin/ProductMargin.java
@@ -26,6 +26,7 @@ import com.acadiasoft.im.base.imtree.ImTree;
 import com.acadiasoft.im.base.imtree.identifiers.MarginIdentifier;
 import com.acadiasoft.im.simm.model.imtree.identifiers.ProductClass;
 import com.acadiasoft.im.simm.model.Sensitivity;
+import com.acadiasoft.im.simm.model.param.HoldingPeriod;
 import com.acadiasoft.im.simm.model.param.SimmRiskClassCorrelation;
 import com.acadiasoft.im.base.util.BigDecimalUtils;
 import com.acadiasoft.im.simm.model.utils.SensitivityUtils;
@@ -69,9 +70,9 @@ public class ProductMargin implements ImTree {
     return LEVEL;
   }
 
-  public static ProductMargin calculate(ProductClass product, List<Sensitivity> sensitivities) {
+  public static ProductMargin calculate(ProductClass product, List<Sensitivity> sensitivities, HoldingPeriod holdingPeriod) {
     List<RiskMargin> marginByRiskClass = SensitivityUtils.listByMargin(
-        e -> RiskMargin.calculate(e.getKey(), e.getValue()),
+        e -> RiskMargin.calculate(e.getKey(), e.getValue(), holdingPeriod),
         SensitivityUtils.mapByIdentifier(s -> s.getRiskIdentifier(), sensitivities)
     );
     BigDecimal sumSquared = BigDecimalUtils.sumSquared(marginByRiskClass, m -> m.getMargin());

--- a/simm/src/main/java/com/acadiasoft/im/simm/engine/margin/RiskMargin.java
+++ b/simm/src/main/java/com/acadiasoft/im/simm/engine/margin/RiskMargin.java
@@ -27,6 +27,7 @@ import com.acadiasoft.im.base.imtree.identifiers.MarginIdentifier;
 import com.acadiasoft.im.simm.model.imtree.identifiers.RiskClass;
 import com.acadiasoft.im.simm.model.Sensitivity;
 import com.acadiasoft.im.base.util.BigDecimalUtils;
+import com.acadiasoft.im.simm.model.param.HoldingPeriod;
 import com.acadiasoft.im.simm.model.utils.SensitivityUtils;
 
 import java.math.BigDecimal;
@@ -75,9 +76,9 @@ public class RiskMargin implements ImTree {
     return riskClass;
   }
 
-  public static RiskMargin calculate(RiskClass riskClass, List<Sensitivity> sensitivities) {
+  public static RiskMargin calculate(RiskClass riskClass, List<Sensitivity> sensitivities, HoldingPeriod holdingPeriod) {
     List<SensitivityMargin> marginBySensitivityClass = SensitivityUtils.listByMargin(
-        e -> SensitivityMargin.calculate(riskClass, e.getKey(), e.getValue()),
+        e -> SensitivityMargin.calculate(riskClass, e.getKey(), e.getValue(), holdingPeriod),
         SensitivityUtils.mapByIdentifier(s -> s.getSensitivityIdentifier(), sensitivities)
     );
     // we sum across the sensitivity margins in the Risk Class to get the total IM for that Risk Class

--- a/simm/src/main/java/com/acadiasoft/im/simm/engine/margin/WeightingMargin.java
+++ b/simm/src/main/java/com/acadiasoft/im/simm/engine/margin/WeightingMargin.java
@@ -25,6 +25,7 @@ package com.acadiasoft.im.simm.engine.margin;
 import com.acadiasoft.im.base.imtree.ImTree;
 import com.acadiasoft.im.base.imtree.identifiers.MarginIdentifier;
 import com.acadiasoft.im.simm.model.imtree.identifiers.WeightingClass;
+import com.acadiasoft.im.simm.model.param.HoldingPeriod;
 import com.acadiasoft.im.simm.model.utils.ConcentrationRiskGroup;
 import com.acadiasoft.im.simm.model.Sensitivity;
 import com.acadiasoft.im.simm.model.param.SimmRiskWeight;
@@ -46,9 +47,9 @@ public class WeightingMargin implements ImTree {
     this.concentrationRiskClass = concentrationRiskClass;
   }
 
-  public static WeightingMargin calculate(Sensitivity sensitivity, ConcentrationRiskGroup concentrationRiskClass) {
+  public static WeightingMargin calculate(Sensitivity sensitivity, ConcentrationRiskGroup concentrationRiskClass, HoldingPeriod holdingPeriod) {
     WeightingClass weightingClass = WeightingClass.determineWeightingClass(sensitivity.getWeightingClassIdentifier());
-    BigDecimal riskWeight = SimmRiskWeight.get(sensitivity.getSensitivityIdentifier(), weightingClass);
+    BigDecimal riskWeight = SimmRiskWeight.get(sensitivity.getSensitivityIdentifier(), weightingClass, holdingPeriod);
     BigDecimal amountUsd = sensitivity.getAmountUsd();
     BigDecimal concentrationRisk = concentrationRiskClass.getConcentrationRisk();
     return new WeightingMargin(weightingClass, riskWeight.multiply(amountUsd).multiply(concentrationRisk), concentrationRiskClass);

--- a/simm/src/main/java/com/acadiasoft/im/simm/model/param/HoldingPeriod.java
+++ b/simm/src/main/java/com/acadiasoft/im/simm/model/param/HoldingPeriod.java
@@ -1,0 +1,3 @@
+package com.acadiasoft.im.simm.model.param;
+
+public enum HoldingPeriod {TenDay, OneDay}

--- a/simm/src/main/java/com/acadiasoft/im/simm/model/param/SimmConcentrationThreshold.java
+++ b/simm/src/main/java/com/acadiasoft/im/simm/model/param/SimmConcentrationThreshold.java
@@ -30,6 +30,7 @@ import com.acadiasoft.im.simm.model.param.cq.CreditQualifyingConcentrationRiskV2
 import com.acadiasoft.im.simm.model.param.equity.EquityConcentrationRiskV2_1;
 import com.acadiasoft.im.simm.model.param.fx.FXConcentrationRiskV2_1;
 import com.acadiasoft.im.simm.model.param.interestrate.InterestRateConcentrationRiskV2_1;
+import com.acadiasoft.im.simm.model.utils.ConcentrationRiskGroup;
 
 import java.math.BigDecimal;
 

--- a/simm/src/main/java/com/acadiasoft/im/simm/model/param/SimmHvr.java
+++ b/simm/src/main/java/com/acadiasoft/im/simm/model/param/SimmHvr.java
@@ -33,15 +33,20 @@ public interface SimmHvr {
   BigDecimal FX_HVR = new BigDecimal("0.63");
   BigDecimal IR_HVR = new BigDecimal("0.62");
 
-  public static BigDecimal get(RiskClass riskClass) {
+  BigDecimal CM_HVR_1D = new BigDecimal("0.71");
+  BigDecimal EQ_HVR_1D = new BigDecimal("0.54");
+  BigDecimal FX_HVR_1D = new BigDecimal("0.81");
+  BigDecimal IR_HVR_1D = new BigDecimal("0.67");
+
+  public static BigDecimal get(RiskClass riskClass, HoldingPeriod holdingPeriod) {
     if (riskClass.equals(RiskClass.COMMODITY)) {
-      return CM_HVR;
+      return holdingPeriod == HoldingPeriod.TenDay ? CM_HVR : CM_HVR_1D;
     } else if (riskClass.equals(RiskClass.EQUITY)) {
-      return EQ_HVR;
+      return holdingPeriod == HoldingPeriod.TenDay ? EQ_HVR : EQ_HVR_1D;
     } else if (riskClass.equals(RiskClass.FX)) {
-      return FX_HVR;
+      return holdingPeriod == HoldingPeriod.TenDay ? FX_HVR : FX_HVR_1D;
     } else if (riskClass.equals(RiskClass.INTEREST_RATE)) {
-      return IR_HVR;
+      return holdingPeriod == HoldingPeriod.TenDay ? IR_HVR : IR_HVR_1D;
     } else {
       throw new RuntimeException("tried to get HVR for non-HVR risk class: [" + riskClass + "]!");
     }

--- a/simm/src/main/java/com/acadiasoft/im/simm/model/param/SimmRiskWeight.java
+++ b/simm/src/main/java/com/acadiasoft/im/simm/model/param/SimmRiskWeight.java
@@ -25,45 +25,63 @@ package com.acadiasoft.im.simm.model.param;
 import com.acadiasoft.im.simm.model.imtree.identifiers.RiskClass;
 import com.acadiasoft.im.simm.model.imtree.identifiers.SensitivityClass;
 import com.acadiasoft.im.simm.model.imtree.identifiers.WeightingClass;
+import com.acadiasoft.im.simm.model.param.cnq.CreditNonQualifyingOneDayRiskWeightV2_1;
 import com.acadiasoft.im.simm.model.param.cnq.CreditNonQualifyingRiskWeightV2_1;
+import com.acadiasoft.im.simm.model.param.commodity.CommodityOneDayRiskWeightV2_1;
 import com.acadiasoft.im.simm.model.param.commodity.CommodityRiskWeightV2_1;
+import com.acadiasoft.im.simm.model.param.cq.CreditQualifyingOneDayRiskWeightV2_1;
 import com.acadiasoft.im.simm.model.param.cq.CreditQualifyingRiskWeightV2_1;
+import com.acadiasoft.im.simm.model.param.equity.EquityRiskOneDayWeightV2_1;
 import com.acadiasoft.im.simm.model.param.equity.EquityRiskWeightV2_1;
+import com.acadiasoft.im.simm.model.param.fx.FXRiskOneDayWeightV2_1;
 import com.acadiasoft.im.simm.model.param.fx.FXRiskWeightV2_1;
+import com.acadiasoft.im.simm.model.param.interestrate.InterestRateOneDayRiskWeightV2_1;
 import com.acadiasoft.im.simm.model.param.interestrate.InterestRateRiskWeightV2_1;
 
 import java.math.BigDecimal;
 
 public interface SimmRiskWeight {
 
-  public static BigDecimal get(SensitivityClass s, WeightingClass weightingClass) {
+  public static BigDecimal get(SensitivityClass s, WeightingClass weightingClass, HoldingPeriod holdingPeriod) {
     RiskClass r = weightingClass.getRiskClass();
     if (s.equals(SensitivityClass.DELTA)) {
-      return fromRiskClass(r).getDeltaRiskWeight(weightingClass);
+      return fromRiskClass(r, holdingPeriod).getDeltaRiskWeight(weightingClass);
     } else if (s.equals(SensitivityClass.VEGA)) {
-      return fromRiskClass(r).getVegaRiskWeight(weightingClass);
+      return fromRiskClass(r, holdingPeriod).getVegaRiskWeight(weightingClass);
     } else if (s.equals(SensitivityClass.CURVATURE)) {
       return BigDecimal.ONE;
     } else if (s.equals(SensitivityClass.BASECORR)) {
-      return SimmRiskWeightBaseCorr.get(weightingClass);
+      return SimmRiskWeightBaseCorr.get(weightingClass, holdingPeriod);
     } else {
       throw new IllegalStateException("tried to get risk weight for unexpected sensitivity type: " + s + "]!");
     }
   }
 
-  public static SimmRiskWeight fromRiskClass(RiskClass riskClass) {
+  static SimmRiskWeight fromRiskClass(RiskClass riskClass, HoldingPeriod hp) {
     if (riskClass.equals(RiskClass.INTEREST_RATE)) {
-      return new InterestRateRiskWeightV2_1();
+      return hp == HoldingPeriod.TenDay
+              ? new InterestRateRiskWeightV2_1()
+              : new InterestRateOneDayRiskWeightV2_1();
     } else if (riskClass.equals(RiskClass.CREDIT_QUALIFYING)) {
-      return new CreditQualifyingRiskWeightV2_1();
+      return hp == HoldingPeriod.TenDay
+              ? new CreditQualifyingRiskWeightV2_1()
+              : new CreditQualifyingOneDayRiskWeightV2_1();
     } else if (riskClass.equals(RiskClass.CREDIT_NON_QUALIFYING)) {
-      return new CreditNonQualifyingRiskWeightV2_1();
+      return hp == HoldingPeriod.TenDay
+              ? new CreditNonQualifyingRiskWeightV2_1()
+              : new CreditNonQualifyingOneDayRiskWeightV2_1();
     } else if (riskClass.equals(RiskClass.EQUITY)) {
-      return new EquityRiskWeightV2_1();
+      return hp == HoldingPeriod.TenDay
+              ? new EquityRiskWeightV2_1()
+              : new EquityRiskOneDayWeightV2_1();
     } else if (riskClass.equals(RiskClass.COMMODITY)) {
-      return new CommodityRiskWeightV2_1();
+      return hp == HoldingPeriod.TenDay
+              ? new CommodityRiskWeightV2_1()
+              : new CommodityOneDayRiskWeightV2_1();
     } else if (riskClass.equals(RiskClass.FX)) {
-      return new FXRiskWeightV2_1();
+      return hp == HoldingPeriod.TenDay
+              ? new FXRiskWeightV2_1()
+              : new FXRiskOneDayWeightV2_1();
     } else {
       throw new IllegalStateException("tried to get a threshold for unknown risk class: [" + riskClass + "]!");
     }

--- a/simm/src/main/java/com/acadiasoft/im/simm/model/param/SimmRiskWeightBaseCorr.java
+++ b/simm/src/main/java/com/acadiasoft/im/simm/model/param/SimmRiskWeightBaseCorr.java
@@ -29,10 +29,10 @@ import java.math.BigDecimal;
 
 public interface SimmRiskWeightBaseCorr {
 
-  public static BigDecimal get(WeightingClass weightingClass) {
-    return new BaseCorrRiskV2_1().getRiskWeight(weightingClass);
+  public static BigDecimal get(WeightingClass weightingClass, HoldingPeriod holdingPeriod) {
+    return new BaseCorrRiskV2_1().getRiskWeight(weightingClass, holdingPeriod);
   }
 
-  public BigDecimal getRiskWeight(WeightingClass w);
+  public BigDecimal getRiskWeight(WeightingClass w, HoldingPeriod holdingPeriod);
 
 }

--- a/simm/src/main/java/com/acadiasoft/im/simm/model/param/cnq/CreditNonQualifyingOneDayRiskWeightV2_1.java
+++ b/simm/src/main/java/com/acadiasoft/im/simm/model/param/cnq/CreditNonQualifyingOneDayRiskWeightV2_1.java
@@ -1,0 +1,33 @@
+package com.acadiasoft.im.simm.model.param.cnq;
+
+import com.acadiasoft.im.simm.model.imtree.identifiers.BucketType;
+import com.acadiasoft.im.simm.model.imtree.identifiers.WeightingClass;
+import com.acadiasoft.im.simm.model.param.SimmRiskWeight;
+
+import java.math.BigDecimal;
+import java.util.HashMap;
+import java.util.Map;
+
+public class CreditNonQualifyingOneDayRiskWeightV2_1 implements SimmRiskWeight {
+
+  private static final Map<BucketType, BigDecimal> WEIGHTS = new HashMap<>();
+
+  static {
+    WEIGHTS.put(BucketType.CRNQ1, new BigDecimal("36"));
+    WEIGHTS.put(BucketType.CRNQ2, new BigDecimal("200"));
+    WEIGHTS.put(BucketType.CRNQRESIDUAL, new BigDecimal("200"));
+  }
+
+  private static final BigDecimal VEGA = new BigDecimal("0.07");
+
+  @Override
+  public BigDecimal getDeltaRiskWeight(WeightingClass s) {
+    return WEIGHTS.get(s.getBucketIdentifier().getBucketType());
+  }
+
+  @Override
+  public BigDecimal getVegaRiskWeight(WeightingClass s) {
+    return VEGA;
+  }
+
+}

--- a/simm/src/main/java/com/acadiasoft/im/simm/model/param/commodity/CommodityOneDayRiskWeightV2_1.java
+++ b/simm/src/main/java/com/acadiasoft/im/simm/model/param/commodity/CommodityOneDayRiskWeightV2_1.java
@@ -1,0 +1,46 @@
+package com.acadiasoft.im.simm.model.param.commodity;
+
+import com.acadiasoft.im.simm.model.imtree.identifiers.BucketType;
+import com.acadiasoft.im.simm.model.imtree.identifiers.WeightingClass;
+import com.acadiasoft.im.simm.model.param.SimmRiskWeight;
+
+import java.math.BigDecimal;
+import java.util.HashMap;
+import java.util.Map;
+
+public class CommodityOneDayRiskWeightV2_1 implements SimmRiskWeight {
+
+  private static final Map<BucketType, BigDecimal> WEIGHTS = new HashMap<>();
+
+  static {
+    WEIGHTS.put(BucketType.CM1, new BigDecimal("5.7"));
+    WEIGHTS.put(BucketType.CM2, new BigDecimal("8.4"));
+    WEIGHTS.put(BucketType.CM3, new BigDecimal("6.5"));
+    WEIGHTS.put(BucketType.CM4, new BigDecimal("6.8"));
+    WEIGHTS.put(BucketType.CM5, new BigDecimal("10"));
+    WEIGHTS.put(BucketType.CM6, new BigDecimal("7.5"));
+    WEIGHTS.put(BucketType.CM7, new BigDecimal("7.9"));
+    WEIGHTS.put(BucketType.CM8, new BigDecimal("16"));
+    WEIGHTS.put(BucketType.CM9, new BigDecimal("6.7"));
+    WEIGHTS.put(BucketType.CM10, new BigDecimal("12"));
+    WEIGHTS.put(BucketType.CM11, new BigDecimal("6.4"));
+    WEIGHTS.put(BucketType.CM12, new BigDecimal("6.0"));
+    WEIGHTS.put(BucketType.CM13, new BigDecimal("5.5"));
+    WEIGHTS.put(BucketType.CM14, new BigDecimal("4.7"));
+    WEIGHTS.put(BucketType.CM15, new BigDecimal("3.1"));
+    WEIGHTS.put(BucketType.CM16, new BigDecimal("16"));
+    WEIGHTS.put(BucketType.CM17, new BigDecimal("4.7"));
+  }
+
+  private static final BigDecimal VEGA = new BigDecimal("0.097");
+
+  @Override
+  public BigDecimal getDeltaRiskWeight(WeightingClass s) {
+    return WEIGHTS.get(s.getBucketIdentifier().getBucketType());
+  }
+
+  @Override
+  public BigDecimal getVegaRiskWeight(WeightingClass s) {
+    return VEGA;
+  }
+}

--- a/simm/src/main/java/com/acadiasoft/im/simm/model/param/cq/BaseCorrRiskV2_1.java
+++ b/simm/src/main/java/com/acadiasoft/im/simm/model/param/cq/BaseCorrRiskV2_1.java
@@ -23,6 +23,7 @@
 package com.acadiasoft.im.simm.model.param.cq;
 
 import com.acadiasoft.im.simm.model.imtree.identifiers.WeightingClass;
+import com.acadiasoft.im.simm.model.param.HoldingPeriod;
 import com.acadiasoft.im.simm.model.param.SimmRiskWeightBaseCorr;
 import com.acadiasoft.im.simm.model.param.SimmSensitivityCorrelationBaseCorr;
 
@@ -31,10 +32,12 @@ import java.math.BigDecimal;
 public class BaseCorrRiskV2_1 implements SimmRiskWeightBaseCorr, SimmSensitivityCorrelationBaseCorr {
 
   @Override
-  public BigDecimal getRiskWeight(WeightingClass w) {
+  public BigDecimal getRiskWeight(WeightingClass w, HoldingPeriod holdingPeriod) {
     // currently only one org.acadiasoft.simm.model.risk weight for base corr but the method is here
     // to handle a more complex weighting system if necessary
-    return new BigDecimal("19");
+    return holdingPeriod == HoldingPeriod.TenDay
+            ? new BigDecimal("19")
+            : new BigDecimal("6.1");
   }
 
   @Override

--- a/simm/src/main/java/com/acadiasoft/im/simm/model/param/cq/CreditQualifyingOneDayRiskWeightV2_1.java
+++ b/simm/src/main/java/com/acadiasoft/im/simm/model/param/cq/CreditQualifyingOneDayRiskWeightV2_1.java
@@ -1,0 +1,43 @@
+package com.acadiasoft.im.simm.model.param.cq;
+
+import com.acadiasoft.im.simm.model.imtree.identifiers.BucketType;
+import com.acadiasoft.im.simm.model.imtree.identifiers.WeightingClass;
+import com.acadiasoft.im.simm.model.param.SimmRiskWeight;
+
+import java.math.BigDecimal;
+import java.util.HashMap;
+import java.util.Map;
+
+public class CreditQualifyingOneDayRiskWeightV2_1 implements SimmRiskWeight {
+
+  private static final Map<BucketType, BigDecimal> WEIGHTS = new HashMap<>();
+
+  static {
+    WEIGHTS.put(BucketType.CRQ1, new BigDecimal("19"));
+    WEIGHTS.put(BucketType.CRQ2, new BigDecimal("25"));
+    WEIGHTS.put(BucketType.CRQ3, new BigDecimal("17"));
+    WEIGHTS.put(BucketType.CRQ4, new BigDecimal("13"));
+    WEIGHTS.put(BucketType.CRQ5, new BigDecimal("12"));
+    WEIGHTS.put(BucketType.CRQ6, new BigDecimal("9.9"));
+    WEIGHTS.put(BucketType.CRQ7, new BigDecimal("40"));
+    WEIGHTS.put(BucketType.CRQ8, new BigDecimal("40"));
+    WEIGHTS.put(BucketType.CRQ9, new BigDecimal("33"));
+    WEIGHTS.put(BucketType.CRQ10, new BigDecimal("38"));
+    WEIGHTS.put(BucketType.CRQ11, new BigDecimal("29"));
+    WEIGHTS.put(BucketType.CRQ12, new BigDecimal("31"));
+    WEIGHTS.put(BucketType.CRQRESIDUAL, new BigDecimal("40"));
+  }
+
+  private static final BigDecimal VEGA = new BigDecimal("0.07");
+
+  @Override
+  public BigDecimal getDeltaRiskWeight(WeightingClass s) {
+    return WEIGHTS.get(s.getBucketIdentifier().getBucketType());
+  }
+
+  @Override
+  public BigDecimal getVegaRiskWeight(WeightingClass s) {
+    return VEGA;
+  }
+
+}

--- a/simm/src/main/java/com/acadiasoft/im/simm/model/param/equity/EquityRiskOneDayWeightV2_1.java
+++ b/simm/src/main/java/com/acadiasoft/im/simm/model/param/equity/EquityRiskOneDayWeightV2_1.java
@@ -1,0 +1,49 @@
+package com.acadiasoft.im.simm.model.param.equity;
+
+import com.acadiasoft.im.simm.model.imtree.identifiers.BucketType;
+import com.acadiasoft.im.simm.model.imtree.identifiers.WeightingClass;
+import com.acadiasoft.im.simm.model.param.SimmRiskWeight;
+
+import java.math.BigDecimal;
+import java.util.HashMap;
+import java.util.Map;
+
+public class EquityRiskOneDayWeightV2_1 implements SimmRiskWeight {
+
+  private static final Map<BucketType, BigDecimal> WEIGHTS = new HashMap<>();
+
+  static {
+    WEIGHTS.put(BucketType.EQ1, new BigDecimal("8.3"));
+    WEIGHTS.put(BucketType.EQ2, new BigDecimal("10"));
+    WEIGHTS.put(BucketType.EQ3, new BigDecimal("10"));
+    WEIGHTS.put(BucketType.EQ4, new BigDecimal("8.6"));
+    WEIGHTS.put(BucketType.EQ5, new BigDecimal("7.1"));
+    WEIGHTS.put(BucketType.EQ6, new BigDecimal("7.4"));
+    WEIGHTS.put(BucketType.EQ7, new BigDecimal("9.2"));
+    WEIGHTS.put(BucketType.EQ8, new BigDecimal("8.7"));
+    WEIGHTS.put(BucketType.EQ9, new BigDecimal("10"));
+    WEIGHTS.put(BucketType.EQ10, new BigDecimal("11"));
+    WEIGHTS.put(BucketType.EQ11, new BigDecimal("6.4"));
+    WEIGHTS.put(BucketType.EQ12, new BigDecimal("6.4"));
+    WEIGHTS.put(BucketType.EQRESIDUAL, new BigDecimal("11"));
+  }
+
+  private static final BigDecimal VEGA = new BigDecimal("0.075");
+  private static final BigDecimal VEGA12 = new BigDecimal("0.19");
+
+  @Override
+  public BigDecimal getDeltaRiskWeight(WeightingClass s) {
+    return WEIGHTS.get(s.getBucketIdentifier().getBucketType());
+  }
+
+  @Override
+  public BigDecimal getVegaRiskWeight(WeightingClass s) {
+    if (s.getBucket().equals("12")) {
+      // bucket 12 has its own VRW as per doc/ISDA-SIMM-v1.3.38 paragraph 57
+      return VEGA12;
+    } else {
+      return VEGA;
+    }
+  }
+
+}

--- a/simm/src/main/java/com/acadiasoft/im/simm/model/param/fx/FXRiskOneDayWeightV2_1.java
+++ b/simm/src/main/java/com/acadiasoft/im/simm/model/param/fx/FXRiskOneDayWeightV2_1.java
@@ -1,0 +1,24 @@
+package com.acadiasoft.im.simm.model.param.fx;
+
+import com.acadiasoft.im.simm.model.imtree.identifiers.WeightingClass;
+import com.acadiasoft.im.simm.model.param.SimmRiskWeight;
+
+import java.math.BigDecimal;
+
+public class FXRiskOneDayWeightV2_1 implements SimmRiskWeight {
+
+  private static final BigDecimal ALL = new BigDecimal("2.0");
+  private static final BigDecimal VEGA = new BigDecimal("0.079");
+
+  @Override
+  public BigDecimal getDeltaRiskWeight(WeightingClass s) {
+    // only one bucket for all currencies in FX org.acadiasoft.simm.model.risk class
+    return ALL;
+  }
+
+  @Override
+  public BigDecimal getVegaRiskWeight(WeightingClass s) {
+    return VEGA;
+  }
+
+}

--- a/simm/src/main/java/com/acadiasoft/im/simm/model/param/interestrate/InterestRateOneDayRiskWeightV2_1.java
+++ b/simm/src/main/java/com/acadiasoft/im/simm/model/param/interestrate/InterestRateOneDayRiskWeightV2_1.java
@@ -1,0 +1,85 @@
+package com.acadiasoft.im.simm.model.param.interestrate;
+
+import com.acadiasoft.im.simm.model.imtree.identifiers.RiskClass;
+import com.acadiasoft.im.simm.model.imtree.identifiers.WeightingClass;
+import com.acadiasoft.im.simm.model.param.SimmRiskWeight;
+import org.apache.commons.lang3.StringUtils;
+
+import java.math.BigDecimal;
+import java.util.HashMap;
+import java.util.Map;
+
+public class InterestRateOneDayRiskWeightV2_1 implements SimmRiskWeight {
+
+  private static final BigDecimal VEGA = new BigDecimal("0.04");
+  private static final BigDecimal INFLATION = new BigDecimal("9.6");
+  private static final BigDecimal XCCY = new BigDecimal("5.6");
+
+  private static final Map<InterestRateCurrencyVolatility, Map<InterestRateTenor, BigDecimal>> WEIGHTS = new HashMap<>();
+  private static final Map<InterestRateTenor, BigDecimal> HIGH = new HashMap<>();
+  private static final Map<InterestRateTenor, BigDecimal> LOW = new HashMap<>();
+  private static final Map<InterestRateTenor, BigDecimal> REGULAR = new HashMap<>();
+
+  static {
+    REGULAR.put(InterestRateTenor._2W, new BigDecimal("22"));
+    REGULAR.put(InterestRateTenor._1M, new BigDecimal("16"));
+    REGULAR.put(InterestRateTenor._3M, new BigDecimal("12"));
+    REGULAR.put(InterestRateTenor._6M, new BigDecimal("12"));
+    REGULAR.put(InterestRateTenor._1YR, new BigDecimal("13"));
+    REGULAR.put(InterestRateTenor._2YR, new BigDecimal("15"));
+    REGULAR.put(InterestRateTenor._3YR, new BigDecimal("15"));
+    REGULAR.put(InterestRateTenor._5YR, new BigDecimal("16"));
+    REGULAR.put(InterestRateTenor._10YR, new BigDecimal("17"));
+    REGULAR.put(InterestRateTenor._15YR, new BigDecimal("15"));
+    REGULAR.put(InterestRateTenor._20YR, new BigDecimal("16"));
+    REGULAR.put(InterestRateTenor._30YR, new BigDecimal("16"));
+    WEIGHTS.put(InterestRateCurrencyVolatility.REGULAR, REGULAR);
+
+    LOW.put(InterestRateTenor._2W, new BigDecimal("12"));
+    LOW.put(InterestRateTenor._1M, new BigDecimal("3.5"));
+    LOW.put(InterestRateTenor._3M, new BigDecimal("1.7"));
+    LOW.put(InterestRateTenor._6M, new BigDecimal("1.7"));
+    LOW.put(InterestRateTenor._1YR, new BigDecimal("3.2"));
+    LOW.put(InterestRateTenor._2YR, new BigDecimal("4.4"));
+    LOW.put(InterestRateTenor._3YR, new BigDecimal("5.2"));
+    LOW.put(InterestRateTenor._5YR, new BigDecimal("6.9"));
+    LOW.put(InterestRateTenor._10YR, new BigDecimal("7.3"));
+    LOW.put(InterestRateTenor._15YR, new BigDecimal("7.3"));
+    LOW.put(InterestRateTenor._20YR, new BigDecimal("8.1"));
+    LOW.put(InterestRateTenor._30YR, new BigDecimal("8.6"));
+    WEIGHTS.put(InterestRateCurrencyVolatility.LOW_VOLATILITY, LOW);
+
+    HIGH.put(InterestRateTenor._2W, new BigDecimal("32"));
+    HIGH.put(InterestRateTenor._1M, new BigDecimal("38"));
+    HIGH.put(InterestRateTenor._3M, new BigDecimal("22"));
+    HIGH.put(InterestRateTenor._6M, new BigDecimal("21"));
+    HIGH.put(InterestRateTenor._1YR, new BigDecimal("22"));
+    HIGH.put(InterestRateTenor._2YR, new BigDecimal("23"));
+    HIGH.put(InterestRateTenor._3YR, new BigDecimal("26"));
+    HIGH.put(InterestRateTenor._5YR, new BigDecimal("27"));
+    HIGH.put(InterestRateTenor._10YR, new BigDecimal("31"));
+    HIGH.put(InterestRateTenor._15YR, new BigDecimal("27"));
+    HIGH.put(InterestRateTenor._20YR, new BigDecimal("30"));
+    HIGH.put(InterestRateTenor._30YR, new BigDecimal("32"));
+    WEIGHTS.put(InterestRateCurrencyVolatility.HIGH_VOLATILITY, HIGH);
+  }
+
+  @Override
+  public BigDecimal getDeltaRiskWeight(WeightingClass s) {
+    if (StringUtils.equalsIgnoreCase(s.getRiskType(), RiskClass.RISK_TYPE_INFLATION)) {
+      return INFLATION;
+    } else if (s.getRiskType().equalsIgnoreCase(RiskClass.RISK_TYPE_XCCY_BASIS)) {
+      return XCCY;
+    } else {
+      InterestRateCurrencyVolatility vol = InterestRateCurrencyVolatility.get(s.getQualifier());
+      InterestRateTenor tenor = InterestRateTenor.getByTenor(s.getLabel1());
+      return WEIGHTS.get(vol).get(tenor);
+    }
+  }
+
+  @Override
+  public BigDecimal getVegaRiskWeight(WeightingClass s) {
+    return VEGA;
+  }
+
+}

--- a/simm/src/main/java/com/acadiasoft/im/simm/model/param/interestrate/InterestRateRiskWeightV2_1.java
+++ b/simm/src/main/java/com/acadiasoft/im/simm/model/param/interestrate/InterestRateRiskWeightV2_1.java
@@ -108,3 +108,4 @@ public class InterestRateRiskWeightV2_1 implements SimmRiskWeight {
   }
 
 }
+

--- a/simm/src/main/java/com/acadiasoft/im/simm/model/utils/ConcentrationRiskGroup.java
+++ b/simm/src/main/java/com/acadiasoft/im/simm/model/utils/ConcentrationRiskGroup.java
@@ -26,6 +26,7 @@ import com.acadiasoft.im.base.imtree.identifiers.MarginIdentifier;
 import com.acadiasoft.im.simm.model.imtree.identifiers.RiskClass;
 import com.acadiasoft.im.simm.model.imtree.identifiers.SensitivityClass;
 import com.acadiasoft.im.simm.model.Sensitivity;
+import com.acadiasoft.im.simm.model.param.HoldingPeriod;
 import com.acadiasoft.im.simm.model.param.SimmConcentrationThreshold;
 import com.acadiasoft.im.base.util.BigDecimalUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -75,9 +76,10 @@ public class ConcentrationRiskGroup implements Serializable {
   /**
    *
    * @param concentrationGroup list of sensitivities all belonging to the same concentration class
+   * @param holdingPeriod
    * @return concentration class of the input sensitivities
    */
-  public static ConcentrationRiskGroup build(RiskClass riskClass, SensitivityClass sensitivityClass, String identifier, List<Sensitivity> concentrationGroup) {
+  public static ConcentrationRiskGroup build(RiskClass riskClass, SensitivityClass sensitivityClass, String identifier, List<Sensitivity> concentrationGroup, HoldingPeriod holdingPeriod) {
     // we need to remove Xccy Basis sensitivities from this sum
     // base corr sensitivities need to be removed as well, but we filter those out of other sensitivites earlier on
     if (riskClass.equals(RiskClass.INTEREST_RATE)) {
@@ -89,7 +91,7 @@ public class ConcentrationRiskGroup implements Serializable {
     BigDecimal absSum = BigDecimalUtils.sum(concentrationGroup, s -> s.getAmountUsd()).abs();
     BigDecimal threshold = SimmConcentrationThreshold.getThreshold(riskClass, sensitivityClass, identifier);
     BigDecimal concentration = BigDecimalUtils.divideWithPrecision(absSum, threshold);
-    return new ConcentrationRiskGroup(riskClass, sensitivityClass, identifier, BigDecimal.ONE.max(BigDecimalUtils.sqrt(concentration)));
+    return new ConcentrationRiskGroup(riskClass, sensitivityClass, identifier, holdingPeriod == HoldingPeriod.OneDay ? BigDecimal.ONE : BigDecimal.ONE.max(BigDecimalUtils.sqrt(concentration)));
   }
 
   public static ConcentrationRiskGroup findConcentrationClass(String identifier, Map<String, ConcentrationRiskGroup> mapByIdentifier) {

--- a/simm/src/test/java/com/acadiasoft/im/simm/engine/AbstractAcadiaUnitTestV2_0.java
+++ b/simm/src/test/java/com/acadiasoft/im/simm/engine/AbstractAcadiaUnitTestV2_0.java
@@ -256,4 +256,32 @@ public abstract class AbstractAcadiaUnitTestV2_0 {
   public static final AddOnFixedAmount AN10 = new AddOnFixedAmount(new BigDecimal("16500000"));
   public static final AddOnFixedAmount AN11 = new AddOnFixedAmount(new BigDecimal("20000000"));
 
+  // S_CRQ
+  public static final Sensitivity S_CRQ_1 = new Sensitivity("Credit", "Risk_CreditQ",  "ISIN:BE0934259525", "1", "1y", "USD", new BigDecimal("800000"));
+  public static final Sensitivity S_CRQ_1t = new Sensitivity("Credit", "Risk_CreditQ", "ISIN:BE0934259525", "1", "2y", "USD", new BigDecimal("800000"));
+  public static final Sensitivity S_CRQ_2 = new Sensitivity("Credit", "Risk_CreditQ",  "ISIN:BE0934259525", "1", "2y", "USD", new BigDecimal("-300000"));
+  public static final Sensitivity S_CRQ_3 = new Sensitivity("Credit", "Risk_CreditQ", "ISIN:CA112585AG91", "2", "2y", "USD", new BigDecimal("200000"));
+  public static final Sensitivity S_CRQ_4 = new Sensitivity("Credit", "Risk_CreditQ", "ISIN:CA112585AG91", "2", "2y", "EUR", new BigDecimal("-200000"));
+  public static final Sensitivity S_CRQ_5 = new Sensitivity("Credit", "Risk_CreditQ", "ISIN:CA82028KAP62", "3", "3y", "GBP", new BigDecimal("200000"));
+  public static final Sensitivity S_CRQ_6 = new Sensitivity("Credit", "Risk_CreditQ", "ISIN:CA82028KAP62", "3", "5y", "JPY", new BigDecimal("-100000"));
+  public static final Sensitivity S_CRQ_7 = new Sensitivity("Credit", "Risk_CreditQ", "ISIN:FR0000108359", "4", "5y", "USD", new BigDecimal("200000"));
+  public static final Sensitivity S_CRQ_8 = new Sensitivity("Credit", "Risk_CreditQ", "ISIN:FR0000108359", "4", "5y", "USD", new BigDecimal("-100000"));
+  public static final Sensitivity S_CRQ_9 = new Sensitivity("Credit", "Risk_CreditQ", "ISIN:CH0010519475", "5", "10y", "USD", new BigDecimal("200000"));
+  public static final Sensitivity S_CRQ_10 = new Sensitivity("Credit", "Risk_CreditQ", "ISIN:CH9823105801", "5", "1y", "USD", new BigDecimal("-100000"));
+  public static final Sensitivity S_CRQ_11 = new Sensitivity("Credit", "Risk_CreditQ", "ISIN:DE4830528795", "6", "2y", "EUR", new BigDecimal("200000"));
+  public static final Sensitivity S_CRQ_12 = new Sensitivity("Credit", "Risk_CreditQ", "ISIN:GB0862147969", "7", "3y", "GBP", new BigDecimal("-600000"));
+  public static final Sensitivity S_CRQ_13 = new Sensitivity("Credit", "Risk_CreditQ", "ISIN:CA6515779866", "8", "5y", "USD", new BigDecimal("-100000"));
+  public static final Sensitivity S_CRQ_14 = new Sensitivity("Credit", "Risk_CreditQ", "ISIN:FR0003335977", "9", "10y", "USD", new BigDecimal("200000"));
+  public static final Sensitivity S_CRQ_15 = new Sensitivity("Credit", "Risk_CreditQ", "ISIN:CA2201568701", "10", "1y", "USD", new BigDecimal("-100000"));
+  public static final Sensitivity S_CRQ_16 = new Sensitivity("Credit", "Risk_CreditQ", "ISIN:CA6130123456", "11", "2y", "USD", new BigDecimal("200000"));
+  public static final Sensitivity S_CRQ_17 = new Sensitivity("Credit", "Risk_CreditQ", "ISIN:FR0002226543", "12", "3y", "USD", new BigDecimal("-100000"));
+  public static final Sensitivity S_CRQ_18 = new Sensitivity("Credit", "Risk_CreditQ", "ISIN:UNKNOWN1", "Residual", "1y", "USD", new BigDecimal("200000"));
+  public static final Sensitivity S_CRQ_19 = new Sensitivity("Credit", "Risk_CreditQ", "ISIN:UNKNOWN1", "Residual", "3y", "USD", new BigDecimal("-100000"));
+  public static final Sensitivity S_CRQ_20 = new Sensitivity("Credit", "Risk_CreditQ", "ISIN:UNKNOWN2", "Residual", "3y", "EUR", new BigDecimal("200000"));
+  public static final Sensitivity S_CRQ_21 = new Sensitivity("Credit", "Risk_CreditQ", "ISIN:UNKNOWN3", "Residual", "5y", "USD", new BigDecimal("200000"));
+  public static final Sensitivity S_CRQ_22 = new Sensitivity("Credit", "Risk_CreditQ", "ISIN:UNKNOWN3", "Residual", "10y", "GBP", new BigDecimal("-100000"));
+  public static final Sensitivity S_CRQ_23 = new Sensitivity("Credit", "Risk_BaseCorr", "CDX IG", "", "", "", new BigDecimal("500000"));
+  public static final Sensitivity S_CRQ_24 = new Sensitivity("Credit", "Risk_BaseCorr", "CDX IG", "", "", "", new BigDecimal("-200000"));
+  public static final Sensitivity S_CRQ_25 = new Sensitivity("Credit", "Risk_BaseCorr", "iTraxx Main", "", "", "", new BigDecimal("400000"));
+
 }

--- a/simm/src/test/java/com/acadiasoft/im/simm/engine/AcadiaAddOnUnitTestV2_0.java
+++ b/simm/src/test/java/com/acadiasoft/im/simm/engine/AcadiaAddOnUnitTestV2_0.java
@@ -25,6 +25,7 @@ package com.acadiasoft.im.simm.engine;
 import com.acadiasoft.im.base.fx.FxRate;
 import com.acadiasoft.im.simm.model.AddOnNotional;
 import com.acadiasoft.im.simm.model.AddOnNotionalFactor;
+import com.acadiasoft.im.simm.model.param.HoldingPeriod;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -39,7 +40,7 @@ public class AcadiaAddOnUnitTestV2_0 extends AbstractAcadiaUnitTestV2_0 {
 
   @Test // tested: notional
   public void testAN1() {
-    Assert.assertEquals(new BigDecimal("610500"), Simm.calculateAdditional(EMPTY_LIST, EMPTY_MULT, Arrays.asList(AN1), Arrays.asList(AN3), ZERO_FIXED, FxRate.USD).setScale(0, RoundingMode.HALF_UP));
+    Assert.assertEquals(new BigDecimal("610500"), Simm.calculateAdditional(EMPTY_LIST, EMPTY_MULT, Arrays.asList(AN1), Arrays.asList(AN3), ZERO_FIXED, FxRate.USD, HoldingPeriod.TenDay).setScale(0, RoundingMode.HALF_UP));
   }
 
   @Test // tested: notional (netting)
@@ -48,7 +49,7 @@ public class AcadiaAddOnUnitTestV2_0 extends AbstractAcadiaUnitTestV2_0 {
     factors.put(AN1.getProduct(), AN1);
     Map<String, List<AddOnNotional>> notional = new HashMap<>();
     notional.put(AN3.getProduct(), Arrays.asList(AN3, AN5));
-    Assert.assertEquals(new BigDecimal("1526250"), Simm.calculateAdditional(EMPTY_LIST, EMPTY_MULT, Arrays.asList(AN1), Arrays.asList(AN3, AN5), ZERO_FIXED, FxRate.USD).setScale(0, RoundingMode.HALF_UP));
+    Assert.assertEquals(new BigDecimal("1526250"), Simm.calculateAdditional(EMPTY_LIST, EMPTY_MULT, Arrays.asList(AN1), Arrays.asList(AN3, AN5), ZERO_FIXED, FxRate.USD, HoldingPeriod.TenDay).setScale(0, RoundingMode.HALF_UP));
   }
 
   @Test // tested: notional (netting with negative (absolute sum))
@@ -57,12 +58,12 @@ public class AcadiaAddOnUnitTestV2_0 extends AbstractAcadiaUnitTestV2_0 {
     factors.put(AN1.getProduct(), AN1);
     Map<String, List<AddOnNotional>> notional = new HashMap<>();
     notional.put(AN3.getProduct(), Arrays.asList(AN3, AN4, AN5));
-    Assert.assertEquals(new BigDecimal("2747250"), Simm.calculateAdditional(EMPTY_LIST, EMPTY_MULT, Arrays.asList(AN1), Arrays.asList(AN3, AN4, AN5), ZERO_FIXED, FxRate.USD).setScale(0, RoundingMode.HALF_UP));
+    Assert.assertEquals(new BigDecimal("2747250"), Simm.calculateAdditional(EMPTY_LIST, EMPTY_MULT, Arrays.asList(AN1), Arrays.asList(AN3, AN4, AN5), ZERO_FIXED, FxRate.USD, HoldingPeriod.TenDay).setScale(0, RoundingMode.HALF_UP));
   }
 
   @Test // tested: notional (two products)
   public void testAN4() {
-    Assert.assertEquals(new BigDecimal("3363750"), Simm.calculateAdditional(EMPTY_LIST, EMPTY_MULT, Arrays.asList(AN1, AN2), Arrays.asList(AN3, AN4, AN5, AN6, AN7), ZERO_FIXED, FxRate.USD).setScale(0, RoundingMode.HALF_UP));
+    Assert.assertEquals(new BigDecimal("3363750"), Simm.calculateAdditional(EMPTY_LIST, EMPTY_MULT, Arrays.asList(AN1, AN2), Arrays.asList(AN3, AN4, AN5, AN6, AN7), ZERO_FIXED, FxRate.USD, HoldingPeriod.TenDay).setScale(0, RoundingMode.HALF_UP));
   }
 
   @Test // tested: notional (non-existent product)
@@ -74,17 +75,17 @@ public class AcadiaAddOnUnitTestV2_0 extends AbstractAcadiaUnitTestV2_0 {
     notional.addAll(Arrays.asList(AN3, AN4, AN5));
     notional.addAll(Arrays.asList(AN6, AN7));
     notional.addAll(Arrays.asList(AN8));
-    Assert.assertEquals(new BigDecimal("3363750"), Simm.calculateAdditional(EMPTY_LIST, EMPTY_MULT, factors, notional, ZERO_FIXED, FxRate.USD).setScale(0, RoundingMode.HALF_UP));
+    Assert.assertEquals(new BigDecimal("3363750"), Simm.calculateAdditional(EMPTY_LIST, EMPTY_MULT, factors, notional, ZERO_FIXED, FxRate.USD, HoldingPeriod.TenDay).setScale(0, RoundingMode.HALF_UP));
   }
 
   @Test // tested: fixed (one)
   public void testAN6() {
-    Assert.assertEquals(new BigDecimal("16500000"), Simm.calculateAdditional(EMPTY_LIST, EMPTY_MULT, EMPTY_FACTORS, EMPTY_NOTIONALS, Arrays.asList(AN10), FxRate.USD).setScale(0, RoundingMode.HALF_UP));
+    Assert.assertEquals(new BigDecimal("16500000"), Simm.calculateAdditional(EMPTY_LIST, EMPTY_MULT, EMPTY_FACTORS, EMPTY_NOTIONALS, Arrays.asList(AN10), FxRate.USD, HoldingPeriod.TenDay).setScale(0, RoundingMode.HALF_UP));
   }
 
   @Test // tested: fixed (multiple)
   public void testAN7() {
-    Assert.assertEquals(new BigDecimal("36500000"), Simm.calculateAdditional(EMPTY_LIST, EMPTY_MULT, EMPTY_FACTORS, EMPTY_NOTIONALS, Arrays.asList(AN10, AN11), FxRate.USD).setScale(0, RoundingMode.HALF_UP));
+    Assert.assertEquals(new BigDecimal("36500000"), Simm.calculateAdditional(EMPTY_LIST, EMPTY_MULT, EMPTY_FACTORS, EMPTY_NOTIONALS, Arrays.asList(AN10, AN11), FxRate.USD, HoldingPeriod.TenDay).setScale(0, RoundingMode.HALF_UP));
   }
 
   @Test // tested: notional (non-existent product)
@@ -97,7 +98,7 @@ public class AcadiaAddOnUnitTestV2_0 extends AbstractAcadiaUnitTestV2_0 {
     notional.addAll(Arrays.asList(AN6, AN7));
     notional.addAll(Arrays.asList(AN8));
     notional.addAll(Arrays.asList(AN9));
-    Assert.assertEquals(new BigDecimal("19863750"), Simm.calculateAdditional(EMPTY_LIST, EMPTY_MULT, factors, notional, Arrays.asList(AN10), FxRate.USD).setScale(0, RoundingMode.HALF_UP));
+    Assert.assertEquals(new BigDecimal("19863750"), Simm.calculateAdditional(EMPTY_LIST, EMPTY_MULT, factors, notional, Arrays.asList(AN10), FxRate.USD, HoldingPeriod.TenDay).setScale(0, RoundingMode.HALF_UP));
   }
 
 }

--- a/simm/src/test/java/com/acadiasoft/im/simm/engine/AcadiaDeltaUnitTestV2_0.java
+++ b/simm/src/test/java/com/acadiasoft/im/simm/engine/AcadiaDeltaUnitTestV2_0.java
@@ -24,6 +24,7 @@ package com.acadiasoft.im.simm.engine;
 
 import com.acadiasoft.im.base.fx.FxRate;
 import com.acadiasoft.im.simm.model.Sensitivity;
+import com.acadiasoft.im.simm.model.param.HoldingPeriod;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -39,400 +40,400 @@ public class AcadiaDeltaUnitTestV2_0 extends AbstractAcadiaUnitTestV2_0 {
 
   @Test // tested: regular vol
   public void testIR1() {
-    Assert.assertEquals(new BigDecimal("14200000000"), Simm.calculateStandard(Arrays.asList(IR1), FxRate.USD).setScale(0, RoundingMode.HALF_UP));
+    Assert.assertEquals(new BigDecimal("14200000000"), Simm.calculateStandard(Arrays.asList(IR1), FxRate.USD, HoldingPeriod.TenDay).setScale(0, RoundingMode.HALF_UP));
   }
 
   @Test // tested: regular vol, CR (well traded)
   public void testIR2() {
-    Assert.assertEquals(new BigDecimal("18645566306"), Simm.calculateStandard(Arrays.asList(IR2), FxRate.USD).setScale(0, RoundingMode.HALF_UP));
+    Assert.assertEquals(new BigDecimal("18645566306"), Simm.calculateStandard(Arrays.asList(IR2), FxRate.USD, HoldingPeriod.TenDay).setScale(0, RoundingMode.HALF_UP));
   }
 
   @Test // tested: regular vol, CR (less traded, inflation)
   public void testIR3() {
-    Assert.assertEquals(new BigDecimal("1517893277"), Simm.calculateStandard(Arrays.asList(IR6), FxRate.USD).setScale(0, RoundingMode.HALF_UP));
+    Assert.assertEquals(new BigDecimal("1517893277"), Simm.calculateStandard(Arrays.asList(IR6), FxRate.USD, HoldingPeriod.TenDay).setScale(0, RoundingMode.HALF_UP));
   }
 
   @Test // tested: low vol
   public void testIR4() {
-    Assert.assertEquals(new BigDecimal("230000000"), Simm.calculateStandard(Arrays.asList(IR8), FxRate.USD).setScale(0, RoundingMode.HALF_UP));
+    Assert.assertEquals(new BigDecimal("230000000"), Simm.calculateStandard(Arrays.asList(IR8), FxRate.USD, HoldingPeriod.TenDay).setScale(0, RoundingMode.HALF_UP));
   }
 
   @Test // tested: high vol, CR
   public void testIR5() {
-    Assert.assertEquals(new BigDecimal("2349609897"), Simm.calculateStandard(Arrays.asList(IR9), FxRate.USD).setScale(0, RoundingMode.HALF_UP));
+    Assert.assertEquals(new BigDecimal("2349609897"), Simm.calculateStandard(Arrays.asList(IR9), FxRate.USD, HoldingPeriod.TenDay).setScale(0, RoundingMode.HALF_UP));
   }
 
   @Test // tested: intra-bucket (different sub-curve)
   public void testIR6() {
-    Assert.assertEquals(new BigDecimal("12866994210"), Simm.calculateStandard(Arrays.asList(IR1, IR3), FxRate.USD).setScale(0, RoundingMode.HALF_UP));
+    Assert.assertEquals(new BigDecimal("12866994210"), Simm.calculateStandard(Arrays.asList(IR1, IR3), FxRate.USD, HoldingPeriod.TenDay).setScale(0, RoundingMode.HALF_UP));
   }
 
   @Test // tested: intra-bucket (same sub-curve)
   public void testIR7() {
-    Assert.assertEquals(new BigDecimal("2023872526"), Simm.calculateStandard(Arrays.asList(IR7, IR8), FxRate.USD).setScale(0, RoundingMode.HALF_UP));
+    Assert.assertEquals(new BigDecimal("2023872526"), Simm.calculateStandard(Arrays.asList(IR7, IR8), FxRate.USD, HoldingPeriod.TenDay).setScale(0, RoundingMode.HALF_UP));
   }
 
   @Test // tested: intra-bucket (XCcy to Inflation), CR (XCcy not in sum)
   public void testIR8() {
-    Assert.assertEquals(new BigDecimal("6221583400"), Simm.calculateStandard(Arrays.asList(IR4, IR5), FxRate.USD).setScale(0, RoundingMode.HALF_UP));
+    Assert.assertEquals(new BigDecimal("6221583400"), Simm.calculateStandard(Arrays.asList(IR4, IR5), FxRate.USD, HoldingPeriod.TenDay).setScale(0, RoundingMode.HALF_UP));
   }
 
   @Test // tested: intra-bucket (multiple), CR (XCcy not scaled)
   public void testIR9() {
-    Assert.assertEquals(new BigDecimal("31531158315"), Simm.calculateStandard(Arrays.asList(IR1, IR2, IR3, IR4, IR5), FxRate.USD).setScale(0, RoundingMode.HALF_UP));
+    Assert.assertEquals(new BigDecimal("31531158315"), Simm.calculateStandard(Arrays.asList(IR1, IR2, IR3, IR4, IR5), FxRate.USD, HoldingPeriod.TenDay).setScale(0, RoundingMode.HALF_UP));
   }
 
   @Test // tested: inter-bucket
   public void testIR10() {
-    Assert.assertEquals(new BigDecimal("31779941448"), Simm.calculateStandard(Arrays.asList(IR1, IR2, IR3, IR4, IR5, IR6), FxRate.USD).setScale(0, RoundingMode.HALF_UP));
+    Assert.assertEquals(new BigDecimal("31779941448"), Simm.calculateStandard(Arrays.asList(IR1, IR2, IR3, IR4, IR5, IR6), FxRate.USD, HoldingPeriod.TenDay).setScale(0, RoundingMode.HALF_UP));
   }
 
   @Test // tested: inter-bucket (multiple)
   public void testIR11() {
-    Assert.assertEquals(new BigDecimal("31773442304"), Simm.calculateStandard(Arrays.asList(IR1, IR2, IR3, IR4, IR5, IR6, IR7, IR8, IR9), FxRate.USD).setScale(0, RoundingMode.HALF_UP));
+    Assert.assertEquals(new BigDecimal("31773442304"), Simm.calculateStandard(Arrays.asList(IR1, IR2, IR3, IR4, IR5, IR6, IR7, IR8, IR9), FxRate.USD, HoldingPeriod.TenDay).setScale(0, RoundingMode.HALF_UP));
   }
 
   @Test // tested: product multiplier
   public void testIR12() {
-    Assert.assertEquals(new BigDecimal("38286997977"), Simm.calculateTotal(Arrays.asList(IR1, IR2, IR3, IR4, IR5, IR6, IR7, IR8, IR9), Arrays.asList(IR10), EMPTY_FACTORS, EMPTY_NOTIONALS, ZERO_FIXED, FxRate.USD).setScale(0, RoundingMode.HALF_UP));
+    Assert.assertEquals(new BigDecimal("38286997977"), Simm.calculateTotal(Arrays.asList(IR1, IR2, IR3, IR4, IR5, IR6, IR7, IR8, IR9), Arrays.asList(IR10), EMPTY_FACTORS, EMPTY_NOTIONALS, ZERO_FIXED, FxRate.USD, HoldingPeriod.TenDay).setScale(0, RoundingMode.HALF_UP));
   }
 
   @Test // tested: netting on same risk factor
   public void testFX1() {
-    Assert.assertEquals(BigDecimal.ZERO, Simm.calculateStandard(Arrays.asList(FX1, FX2), FxRate.USD).setScale(0, RoundingMode.HALF_UP));
+    Assert.assertEquals(BigDecimal.ZERO, Simm.calculateStandard(Arrays.asList(FX1, FX2), FxRate.USD, HoldingPeriod.TenDay).setScale(0, RoundingMode.HALF_UP));
   }
 
   @Test // tested: risk weight, CR (Cat 2)
   public void testFX2() {
-    Assert.assertEquals(new BigDecimal("16200000000"), Simm.calculateStandard(Arrays.asList(FX3), FxRate.USD).setScale(0, RoundingMode.HALF_UP));
+    Assert.assertEquals(new BigDecimal("16200000000"), Simm.calculateStandard(Arrays.asList(FX3), FxRate.USD, HoldingPeriod.TenDay).setScale(0, RoundingMode.HALF_UP));
   }
 
   @Test // tested: FX corr param, CR (Cat 2 & 3)
   public void testFX3() {
-    Assert.assertEquals(new BigDecimal("19304527966"), Simm.calculateStandard(Arrays.asList(FX3, FX4), FxRate.USD).setScale(0, RoundingMode.HALF_UP));
+    Assert.assertEquals(new BigDecimal("19304527966"), Simm.calculateStandard(Arrays.asList(FX3, FX4), FxRate.USD, HoldingPeriod.TenDay).setScale(0, RoundingMode.HALF_UP));
   }
 
   @Test // tested: no offsetting corr
   public void testFX4() {
-    Assert.assertEquals(new BigDecimal("19758023687"), Simm.calculateStandard(Arrays.asList(FX1, FX3, FX4), FxRate.USD).setScale(0, RoundingMode.HALF_UP));
+    Assert.assertEquals(new BigDecimal("19758023687"), Simm.calculateStandard(Arrays.asList(FX1, FX3, FX4), FxRate.USD, HoldingPeriod.TenDay).setScale(0, RoundingMode.HALF_UP));
   }
 
   @Test // tested: product multiplier, offsetting correlation
   public void testFX5() {
-    Assert.assertEquals(new BigDecimal("22744268864"), Simm.calculateTotal(Arrays.asList(FX2, FX3, FX4), Arrays.asList(IR10), EMPTY_FACTORS, EMPTY_NOTIONALS, ZERO_FIXED, FxRate.USD).setScale(0, RoundingMode.HALF_UP));
+    Assert.assertEquals(new BigDecimal("22744268864"), Simm.calculateTotal(Arrays.asList(FX2, FX3, FX4), Arrays.asList(IR10), EMPTY_FACTORS, EMPTY_NOTIONALS, ZERO_FIXED, FxRate.USD, HoldingPeriod.TenDay).setScale(0, RoundingMode.HALF_UP));
   }
 
   @Test // tested: product multiplier, Risk Corr (FX to IR)
   public void testRisk1() {
-    Assert.assertEquals(new BigDecimal("49700509702"), Simm.calculateTotal(Arrays.asList(IR1, IR2, IR3, IR4, IR5, IR6, IR7, IR8, IR9, FX1, FX2, FX3, FX4), Arrays.asList(IR10), EMPTY_FACTORS, EMPTY_NOTIONALS, ZERO_FIXED, FxRate.USD).setScale(0, RoundingMode.HALF_UP));
+    Assert.assertEquals(new BigDecimal("49700509702"), Simm.calculateTotal(Arrays.asList(IR1, IR2, IR3, IR4, IR5, IR6, IR7, IR8, IR9, FX1, FX2, FX3, FX4), Arrays.asList(IR10), EMPTY_FACTORS, EMPTY_NOTIONALS, ZERO_FIXED, FxRate.USD, HoldingPeriod.TenDay).setScale(0, RoundingMode.HALF_UP));
   }
 
   @Test // tested: risk weight
   public void testEQ1() {
-    Assert.assertEquals(new BigDecimal("60000000"), Simm.calculateStandard(Arrays.asList(EQ1), FxRate.USD).setScale(0, RoundingMode.HALF_UP));
+    Assert.assertEquals(new BigDecimal("60000000"), Simm.calculateStandard(Arrays.asList(EQ1), FxRate.USD, HoldingPeriod.TenDay).setScale(0, RoundingMode.HALF_UP));
   }
 
   @Test // tested: risk weight, CR
   public void testEQ2() {
-    Assert.assertEquals(new BigDecimal("150000000"), Simm.calculateStandard(Arrays.asList(EQ2), FxRate.USD).setScale(0, RoundingMode.HALF_UP));
+    Assert.assertEquals(new BigDecimal("150000000"), Simm.calculateStandard(Arrays.asList(EQ2), FxRate.USD, HoldingPeriod.TenDay).setScale(0, RoundingMode.HALF_UP));
   }
 
   @Test // tested: risk weight
   public void testEQ3() {
-    Assert.assertEquals(new BigDecimal("210000000"), Simm.calculateStandard(Arrays.asList(EQ3), FxRate.USD).setScale(0, RoundingMode.HALF_UP));
+    Assert.assertEquals(new BigDecimal("210000000"), Simm.calculateStandard(Arrays.asList(EQ3), FxRate.USD, HoldingPeriod.TenDay).setScale(0, RoundingMode.HALF_UP));
   }
 
   @Test // tested: risk weight, CR
   public void testEQ4() {
-    Assert.assertEquals(new BigDecimal("780734787"), Simm.calculateStandard(Arrays.asList(EQ4), FxRate.USD).setScale(0, RoundingMode.HALF_UP));
+    Assert.assertEquals(new BigDecimal("780734787"), Simm.calculateStandard(Arrays.asList(EQ4), FxRate.USD, HoldingPeriod.TenDay).setScale(0, RoundingMode.HALF_UP));
   }
 
   @Test // tested: risk weight (Residual)
   public void testEQ5() {
-    Assert.assertEquals(new BigDecimal("19040000"), Simm.calculateStandard(Arrays.asList(EQ11), FxRate.USD).setScale(0, RoundingMode.HALF_UP));
+    Assert.assertEquals(new BigDecimal("19040000"), Simm.calculateStandard(Arrays.asList(EQ11), FxRate.USD, HoldingPeriod.TenDay).setScale(0, RoundingMode.HALF_UP));
   }
 
   @Test // tested: intra-bucket (no offsets)
   public void testEQ6() {
-    Assert.assertEquals(new BigDecimal("172336879"), Simm.calculateStandard(Arrays.asList(EQ1, EQ2), FxRate.USD).setScale(0, RoundingMode.HALF_UP));
+    Assert.assertEquals(new BigDecimal("172336879"), Simm.calculateStandard(Arrays.asList(EQ1, EQ2), FxRate.USD, HoldingPeriod.TenDay).setScale(0, RoundingMode.HALF_UP));
   }
 
   @Test // tested: intra-bucket (offsetting)
   public void testEQ7() {
-    Assert.assertEquals(new BigDecimal("212089604"), Simm.calculateStandard(Arrays.asList(EQ3, EQ5), FxRate.USD).setScale(0, RoundingMode.HALF_UP));
+    Assert.assertEquals(new BigDecimal("212089604"), Simm.calculateStandard(Arrays.asList(EQ3, EQ5), FxRate.USD, HoldingPeriod.TenDay).setScale(0, RoundingMode.HALF_UP));
   }
 
   @Test // tested: intra-bucket (offsetting, CR corr)
   public void testEQ8() {
-    Assert.assertEquals(new BigDecimal("788071639"), Simm.calculateStandard(Arrays.asList(EQ3, EQ4, EQ5), FxRate.USD).setScale(0, RoundingMode.HALF_UP));
+    Assert.assertEquals(new BigDecimal("788071639"), Simm.calculateStandard(Arrays.asList(EQ3, EQ4, EQ5), FxRate.USD, HoldingPeriod.TenDay).setScale(0, RoundingMode.HALF_UP));
   }
 
   @Test // tested: intra-bucket (Residual)
   public void testEQ9() {
-    Assert.assertEquals(new BigDecimal("31824073"), Simm.calculateStandard(Arrays.asList(EQ10, EQ11), FxRate.USD).setScale(0, RoundingMode.HALF_UP));
+    Assert.assertEquals(new BigDecimal("31824073"), Simm.calculateStandard(Arrays.asList(EQ10, EQ11), FxRate.USD, HoldingPeriod.TenDay).setScale(0, RoundingMode.HALF_UP));
   }
 
   @Test // tested: inter-bucket (offsetting)
   public void testEQ10() {
-    Assert.assertEquals(new BigDecimal("208620708"), Simm.calculateStandard(Arrays.asList(EQ1, EQ3, EQ7, EQ9), FxRate.USD).setScale(0, RoundingMode.HALF_UP));
+    Assert.assertEquals(new BigDecimal("208620708"), Simm.calculateStandard(Arrays.asList(EQ1, EQ3, EQ7, EQ9), FxRate.USD, HoldingPeriod.TenDay).setScale(0, RoundingMode.HALF_UP));
   }
 
   @Test // tested: inter-bucket (offsetting, CR corr)
   public void testEQ11() {
-    Assert.assertEquals(new BigDecimal("847874443"), Simm.calculateStandard(Arrays.asList(EQ1, EQ2, EQ4, EQ5, EQ6, EQ8), FxRate.USD).setScale(0, RoundingMode.HALF_UP));
+    Assert.assertEquals(new BigDecimal("847874443"), Simm.calculateStandard(Arrays.asList(EQ1, EQ2, EQ4, EQ5, EQ6, EQ8), FxRate.USD, HoldingPeriod.TenDay).setScale(0, RoundingMode.HALF_UP));
   }
 
   @Test // tested: multiple
   public void testEQ12() {
-    Assert.assertEquals(new BigDecimal("895893444"), Simm.calculateStandard(Arrays.asList(EQ1, EQ2, EQ3, EQ4, EQ5, EQ6, EQ7, EQ8, EQ9, EQ10, EQ11), FxRate.USD).setScale(0, RoundingMode.HALF_UP));
+    Assert.assertEquals(new BigDecimal("895893444"), Simm.calculateStandard(Arrays.asList(EQ1, EQ2, EQ3, EQ4, EQ5, EQ6, EQ7, EQ8, EQ9, EQ10, EQ11), FxRate.USD, HoldingPeriod.TenDay).setScale(0, RoundingMode.HALF_UP));
   }
 
   @Test // tested: product multiplier
   public void testEQ13() {
-    Assert.assertEquals(new BigDecimal("909331846"), Simm.calculateTotal(Arrays.asList(EQ1, EQ2, EQ3, EQ4, EQ5, EQ6, EQ7, EQ8, EQ9, EQ10, EQ11), Arrays.asList(EQ12), EMPTY_FACTORS, EMPTY_NOTIONALS, ZERO_FIXED, FxRate.USD).setScale(0, RoundingMode.HALF_UP));
+    Assert.assertEquals(new BigDecimal("909331846"), Simm.calculateTotal(Arrays.asList(EQ1, EQ2, EQ3, EQ4, EQ5, EQ6, EQ7, EQ8, EQ9, EQ10, EQ11), Arrays.asList(EQ12), EMPTY_FACTORS, EMPTY_NOTIONALS, ZERO_FIXED, FxRate.USD, HoldingPeriod.TenDay).setScale(0, RoundingMode.HALF_UP));
   }
 
   @Test // tested: risk weight
   public void testCQ1() {
-    Assert.assertEquals(new BigDecimal("69000000"), Simm.calculateStandard(Arrays.asList(CQ1), FxRate.USD).setScale(0, RoundingMode.HALF_UP));
+    Assert.assertEquals(new BigDecimal("69000000"), Simm.calculateStandard(Arrays.asList(CQ1), FxRate.USD, HoldingPeriod.TenDay).setScale(0, RoundingMode.HALF_UP));
   }
 
   @Test // tested: risk weight
   public void testCQ2() {
-    Assert.assertEquals(new BigDecimal("1860488987"), Simm.calculateStandard(Arrays.asList(CQ5), FxRate.USD).setScale(0, RoundingMode.HALF_UP));
+    Assert.assertEquals(new BigDecimal("1860488987"), Simm.calculateStandard(Arrays.asList(CQ5), FxRate.USD, HoldingPeriod.TenDay).setScale(0, RoundingMode.HALF_UP));
   }
 
   @Test // tested: risk weight
   public void testCQ3() {
-    Assert.assertEquals(new BigDecimal("166000000"), Simm.calculateStandard(Arrays.asList(CQ7), FxRate.USD).setScale(0, RoundingMode.HALF_UP));
+    Assert.assertEquals(new BigDecimal("166000000"), Simm.calculateStandard(Arrays.asList(CQ7), FxRate.USD, HoldingPeriod.TenDay).setScale(0, RoundingMode.HALF_UP));
   }
 
   @Test // tested: risk weight
   public void testCQ4() {
-    Assert.assertEquals(new BigDecimal("8326914194"), Simm.calculateStandard(Arrays.asList(CQ11), FxRate.USD).setScale(0, RoundingMode.HALF_UP));
+    Assert.assertEquals(new BigDecimal("8326914194"), Simm.calculateStandard(Arrays.asList(CQ11), FxRate.USD, HoldingPeriod.TenDay).setScale(0, RoundingMode.HALF_UP));
   }
 
   @Test // tested: risk weight
   public void testCQ5() {
-    Assert.assertEquals(new BigDecimal("1983434521"), Simm.calculateStandard(Arrays.asList(CQ15), FxRate.USD).setScale(0, RoundingMode.HALF_UP));
+    Assert.assertEquals(new BigDecimal("1983434521"), Simm.calculateStandard(Arrays.asList(CQ15), FxRate.USD, HoldingPeriod.TenDay).setScale(0, RoundingMode.HALF_UP));
   }
 
   @Test // tested: same issuer/seniority (intra-bucket)
   public void testCQ6() {
-    Assert.assertEquals(new BigDecimal("290210424"), Simm.calculateStandard(Arrays.asList(CQ1, CQ2, CQ3), FxRate.USD).setScale(0, RoundingMode.HALF_UP));
+    Assert.assertEquals(new BigDecimal("290210424"), Simm.calculateStandard(Arrays.asList(CQ1, CQ2, CQ3), FxRate.USD, HoldingPeriod.TenDay).setScale(0, RoundingMode.HALF_UP));
   }
 
   @Test // tested: same issuer/seniority, CR (intra-bucket)
   public void testCQ7() {
-    Assert.assertEquals(new BigDecimal("4200448321"), Simm.calculateStandard(Arrays.asList(CQ1, CQ3), FxRate.USD).setScale(0, RoundingMode.HALF_UP));
+    Assert.assertEquals(new BigDecimal("4200448321"), Simm.calculateStandard(Arrays.asList(CQ1, CQ3), FxRate.USD, HoldingPeriod.TenDay).setScale(0, RoundingMode.HALF_UP));
   }
 
   @Test // tested: different & same issuer/seniority (intra-bucket)
   public void testCQ8() {
-    Assert.assertEquals(new BigDecimal("629565922"), Simm.calculateStandard(Arrays.asList(CQ1, CQ2, CQ3, CQ4), FxRate.USD).setScale(0, RoundingMode.HALF_UP));
+    Assert.assertEquals(new BigDecimal("629565922"), Simm.calculateStandard(Arrays.asList(CQ1, CQ2, CQ3, CQ4), FxRate.USD, HoldingPeriod.TenDay).setScale(0, RoundingMode.HALF_UP));
   }
 
   @Test // tested: different issuer/seniority (same tenor) (intra-bucket)
   public void testCQ9() {
-    Assert.assertEquals(new BigDecimal("1818416923"), Simm.calculateStandard(Arrays.asList(CQ5, CQ6), FxRate.USD).setScale(0, RoundingMode.HALF_UP));
+    Assert.assertEquals(new BigDecimal("1818416923"), Simm.calculateStandard(Arrays.asList(CQ5, CQ6), FxRate.USD, HoldingPeriod.TenDay).setScale(0, RoundingMode.HALF_UP));
   }
 
   @Test // tested: multiple different issuer/seniority (intra-bucket)
   public void testCQ10() {
-    Assert.assertEquals(new BigDecimal("1068608674"), Simm.calculateStandard(Arrays.asList(CQ8, CQ9, CQ10), FxRate.USD).setScale(0, RoundingMode.HALF_UP));
+    Assert.assertEquals(new BigDecimal("1068608674"), Simm.calculateStandard(Arrays.asList(CQ8, CQ9, CQ10), FxRate.USD, HoldingPeriod.TenDay).setScale(0, RoundingMode.HALF_UP));
   }
 
   @Test // tested: CR (netting to be under threshold)
   public void testCQ11() {
-    Assert.assertEquals(new BigDecimal("321490608"), Simm.calculateStandard(Arrays.asList(CQ11, CQ12, CQ13), FxRate.USD).setScale(0, RoundingMode.HALF_UP));
+    Assert.assertEquals(new BigDecimal("321490608"), Simm.calculateStandard(Arrays.asList(CQ11, CQ12, CQ13), FxRate.USD, HoldingPeriod.TenDay).setScale(0, RoundingMode.HALF_UP));
   }
 
   @Test // tested: CR (netting to be over threshold)
   public void testCQ12() {
-    Assert.assertEquals(new BigDecimal("3378851292"), Simm.calculateStandard(Arrays.asList(CQ11, CQ12), FxRate.USD).setScale(0, RoundingMode.HALF_UP));
+    Assert.assertEquals(new BigDecimal("3378851292"), Simm.calculateStandard(Arrays.asList(CQ11, CQ12), FxRate.USD, HoldingPeriod.TenDay).setScale(0, RoundingMode.HALF_UP));
   }
 
   @Test // tested: inter-bucket
   public void testCQ13() {
-    Assert.assertEquals(new BigDecimal("1306838776"), Simm.calculateStandard(Arrays.asList(CQ1, CQ2, CQ3, CQ4, CQ7, CQ8, CQ9, CQ10), FxRate.USD).setScale(0, RoundingMode.HALF_UP));
+    Assert.assertEquals(new BigDecimal("1306838776"), Simm.calculateStandard(Arrays.asList(CQ1, CQ2, CQ3, CQ4, CQ7, CQ8, CQ9, CQ10), FxRate.USD, HoldingPeriod.TenDay).setScale(0, RoundingMode.HALF_UP));
   }
 
   @Test // tested: inter-bucket (multiple)
   public void testCQ14() {
-    Assert.assertEquals(new BigDecimal("1902604112"), Simm.calculateStandard(Arrays.asList(CQ1, CQ2, CQ3, CQ4, CQ5, CQ6, CQ7, CQ8, CQ9, CQ10), FxRate.USD).setScale(0, RoundingMode.HALF_UP));
+    Assert.assertEquals(new BigDecimal("1902604112"), Simm.calculateStandard(Arrays.asList(CQ1, CQ2, CQ3, CQ4, CQ5, CQ6, CQ7, CQ8, CQ9, CQ10), FxRate.USD, HoldingPeriod.TenDay).setScale(0, RoundingMode.HALF_UP));
   }
 
   @Test // tested: intra-bucket (Residual)
   public void testCQ15() {
-    Assert.assertEquals(new BigDecimal("2830853081"), Simm.calculateStandard(Arrays.asList(CQ14, CQ15), FxRate.USD).setScale(0, RoundingMode.HALF_UP));
+    Assert.assertEquals(new BigDecimal("2830853081"), Simm.calculateStandard(Arrays.asList(CQ14, CQ15), FxRate.USD, HoldingPeriod.TenDay).setScale(0, RoundingMode.HALF_UP));
   }
 
   @Test // tested: inter-bucket (multiple w/ residual)
   public void testCQ16() {
-    Assert.assertEquals(new BigDecimal("4757786546"), Simm.calculateStandard(Arrays.asList(CQ1, CQ2, CQ3, CQ4, CQ5, CQ6, CQ7, CQ8, CQ9, CQ10, CQ11, CQ12, CQ13, CQ14, CQ15), FxRate.USD).setScale(0, RoundingMode.HALF_UP));
+    Assert.assertEquals(new BigDecimal("4757786546"), Simm.calculateStandard(Arrays.asList(CQ1, CQ2, CQ3, CQ4, CQ5, CQ6, CQ7, CQ8, CQ9, CQ10, CQ11, CQ12, CQ13, CQ14, CQ15), FxRate.USD, HoldingPeriod.TenDay).setScale(0, RoundingMode.HALF_UP));
   }
 
   @Test // tested: product multiplier
   public void testCQ17() {
-    Assert.assertEquals(new BigDecimal("5281143066"), Simm.calculateTotal(Arrays.asList(CQ1, CQ2, CQ3, CQ4, CQ5, CQ6, CQ7, CQ8, CQ9, CQ10, CQ11, CQ12, CQ13, CQ14, CQ15), Arrays.asList(CQ16), EMPTY_FACTORS, EMPTY_NOTIONALS, ZERO_FIXED, FxRate.USD).setScale(0, RoundingMode.HALF_UP));
+    Assert.assertEquals(new BigDecimal("5281143066"), Simm.calculateTotal(Arrays.asList(CQ1, CQ2, CQ3, CQ4, CQ5, CQ6, CQ7, CQ8, CQ9, CQ10, CQ11, CQ12, CQ13, CQ14, CQ15), Arrays.asList(CQ16), EMPTY_FACTORS, EMPTY_NOTIONALS, ZERO_FIXED, FxRate.USD, HoldingPeriod.TenDay).setScale(0, RoundingMode.HALF_UP));
   }
 
   @Test // tested: risk weight
   public void testBC1() {
-    Assert.assertEquals(new BigDecimal("38000000"), Simm.calculateStandard(Arrays.asList(BC1), FxRate.USD).setScale(0, RoundingMode.HALF_UP));
+    Assert.assertEquals(new BigDecimal("38000000"), Simm.calculateStandard(Arrays.asList(BC1), FxRate.USD, HoldingPeriod.TenDay).setScale(0, RoundingMode.HALF_UP));
   }
 
   @Test // tested: netting
   public void testBC2() {
-    Assert.assertEquals(new BigDecimal("19000000"), Simm.calculateStandard(Arrays.asList(BC1, BC2), FxRate.USD).setScale(0, RoundingMode.HALF_UP));
+    Assert.assertEquals(new BigDecimal("19000000"), Simm.calculateStandard(Arrays.asList(BC1, BC2), FxRate.USD, HoldingPeriod.TenDay).setScale(0, RoundingMode.HALF_UP));
   }
 
   @Test // tested: intra-bucket
   public void testBC3() {
-    Assert.assertEquals(new BigDecimal("86653332"), Simm.calculateStandard(Arrays.asList(BC1, BC2, BC3), FxRate.USD).setScale(0, RoundingMode.HALF_UP));
+    Assert.assertEquals(new BigDecimal("86653332"), Simm.calculateStandard(Arrays.asList(BC1, BC2, BC3), FxRate.USD, HoldingPeriod.TenDay).setScale(0, RoundingMode.HALF_UP));
   }
 
   @Test // tested: intra-bucket (multiple)
   public void testBC4() {
-    Assert.assertEquals(new BigDecimal("89421194"), Simm.calculateStandard(Arrays.asList(BC1, BC2, BC3, BC4), FxRate.USD).setScale(0, RoundingMode.HALF_UP));
+    Assert.assertEquals(new BigDecimal("89421194"), Simm.calculateStandard(Arrays.asList(BC1, BC2, BC3, BC4), FxRate.USD, HoldingPeriod.TenDay).setScale(0, RoundingMode.HALF_UP));
   }
 
   @Test // tested: Base Corr only in Credit Qualifying Risk Class
   public void testRisk2() {
     List<Sensitivity> s = Arrays.asList(CQ1, CQ2, CQ3, CQ4, CQ5, CQ6, CQ7, CQ8, CQ9, CQ10, CQ11, CQ12, CQ13, CQ14, CQ15, BC1, BC2, BC3, BC4);
-    Assert.assertEquals(new BigDecimal("5380400592"), Simm.calculateTotal(s, Arrays.asList(CQ16), EMPTY_FACTORS, EMPTY_NOTIONALS, ZERO_FIXED, FxRate.USD).setScale(0, RoundingMode.HALF_UP));
+    Assert.assertEquals(new BigDecimal("5380400592"), Simm.calculateTotal(s, Arrays.asList(CQ16), EMPTY_FACTORS, EMPTY_NOTIONALS, ZERO_FIXED, FxRate.USD, HoldingPeriod.TenDay).setScale(0, RoundingMode.HALF_UP));
   }
 
   @Test // tested: risk weight
   public void testCNQ1() {
-    Assert.assertEquals(new BigDecimal("450000000"), Simm.calculateStandard(Arrays.asList(CNQ1), FxRate.USD).setScale(0, RoundingMode.HALF_UP));
+    Assert.assertEquals(new BigDecimal("450000000"), Simm.calculateStandard(Arrays.asList(CNQ1), FxRate.USD, HoldingPeriod.TenDay).setScale(0, RoundingMode.HALF_UP));
   }
 
   @Test // tested: risk weight
   public void testCNQ2() {
-    Assert.assertEquals(new BigDecimal("5537710718"), Simm.calculateStandard(Arrays.asList(CNQ4), FxRate.USD).setScale(0, RoundingMode.HALF_UP));
+    Assert.assertEquals(new BigDecimal("5537710718"), Simm.calculateStandard(Arrays.asList(CNQ4), FxRate.USD, HoldingPeriod.TenDay).setScale(0, RoundingMode.HALF_UP));
   }
 
   @Test // tested: risk weight
   public void testCNQ3() {
-    Assert.assertEquals(new BigDecimal("8818163074"), Simm.calculateStandard(Arrays.asList(CNQ7), FxRate.USD).setScale(0, RoundingMode.HALF_UP));
+    Assert.assertEquals(new BigDecimal("8818163074"), Simm.calculateStandard(Arrays.asList(CNQ7), FxRate.USD, HoldingPeriod.TenDay).setScale(0, RoundingMode.HALF_UP));
   }
 
   @Test // tested: intra-bucket (same issuer/seniority), CR (netting to be over threshold)
   public void testCNQ4() {
-    Assert.assertEquals(new BigDecimal("1393084423"), Simm.calculateStandard(Arrays.asList(CNQ1, CNQ2), FxRate.USD).setScale(0, RoundingMode.HALF_UP));
+    Assert.assertEquals(new BigDecimal("1393084423"), Simm.calculateStandard(Arrays.asList(CNQ1, CNQ2), FxRate.USD, HoldingPeriod.TenDay).setScale(0, RoundingMode.HALF_UP));
   }
 
   @Test // tested: intra-bucket (same issuer/seniority), CR (netting to be under threshold)
   public void testCNQ5() {
-    Assert.assertEquals(new BigDecimal("2346606060"), Simm.calculateStandard(Arrays.asList(CNQ4, CNQ5), FxRate.USD).setScale(0, RoundingMode.HALF_UP));
+    Assert.assertEquals(new BigDecimal("2346606060"), Simm.calculateStandard(Arrays.asList(CNQ4, CNQ5), FxRate.USD, HoldingPeriod.TenDay).setScale(0, RoundingMode.HALF_UP));
   }
 
   @Test // tested: intra-bucket (different issuer/seniority)
   public void testCNQ6() {
-    Assert.assertEquals(new BigDecimal("793725393"), Simm.calculateStandard(Arrays.asList(CNQ1, CNQ3), FxRate.USD).setScale(0, RoundingMode.HALF_UP));
+    Assert.assertEquals(new BigDecimal("793725393"), Simm.calculateStandard(Arrays.asList(CNQ1, CNQ3), FxRate.USD, HoldingPeriod.TenDay).setScale(0, RoundingMode.HALF_UP));
   }
 
   @Test // tested: intra-bucket (same & different issuer/seniorty)
   public void testCNQ7() {
-    Assert.assertEquals(new BigDecimal("38459653665"), Simm.calculateStandard(Arrays.asList(CNQ4, CNQ5, CNQ6), FxRate.USD).setScale(0, RoundingMode.HALF_UP));
+    Assert.assertEquals(new BigDecimal("38459653665"), Simm.calculateStandard(Arrays.asList(CNQ4, CNQ5, CNQ6), FxRate.USD, HoldingPeriod.TenDay).setScale(0, RoundingMode.HALF_UP));
   }
 
   @Test // tested: intra-bucket (residual)
   public void testCNQ8() {
-    Assert.assertEquals(new BigDecimal("8453486855"), Simm.calculateStandard(Arrays.asList(CNQ7, CNQ8), FxRate.USD).setScale(0, RoundingMode.HALF_UP));
+    Assert.assertEquals(new BigDecimal("8453486855"), Simm.calculateStandard(Arrays.asList(CNQ7, CNQ8), FxRate.USD, HoldingPeriod.TenDay).setScale(0, RoundingMode.HALF_UP));
   }
 
   @Test // tested: inter-bucket
   public void testCNQ9() {
-    Assert.assertEquals(new BigDecimal("38611298664"), Simm.calculateStandard(Arrays.asList(CNQ1, CNQ2, CNQ3, CNQ4, CNQ5, CNQ6), FxRate.USD).setScale(0, RoundingMode.HALF_UP));
+    Assert.assertEquals(new BigDecimal("38611298664"), Simm.calculateStandard(Arrays.asList(CNQ1, CNQ2, CNQ3, CNQ4, CNQ5, CNQ6), FxRate.USD, HoldingPeriod.TenDay).setScale(0, RoundingMode.HALF_UP));
   }
 
   @Test // tested: inter-bucket (w/ residual)
   public void testCNQ10() {
-    Assert.assertEquals(new BigDecimal("47064785518"), Simm.calculateStandard(Arrays.asList(CNQ1, CNQ2, CNQ3, CNQ4, CNQ5, CNQ6, CNQ7, CNQ8), FxRate.USD).setScale(0, RoundingMode.HALF_UP));
+    Assert.assertEquals(new BigDecimal("47064785518"), Simm.calculateStandard(Arrays.asList(CNQ1, CNQ2, CNQ3, CNQ4, CNQ5, CNQ6, CNQ7, CNQ8), FxRate.USD, HoldingPeriod.TenDay).setScale(0, RoundingMode.HALF_UP));
   }
 
   @Test // tested: product multiplier
   public void testCNQ11() {
-    Assert.assertEquals(new BigDecimal("52241911925"), Simm.calculateTotal(Arrays.asList(CNQ1, CNQ2, CNQ3, CNQ4, CNQ5, CNQ6, CNQ7, CNQ8), Arrays.asList(CQ16), EMPTY_FACTORS, EMPTY_NOTIONALS, ZERO_FIXED, FxRate.USD).setScale(0, RoundingMode.HALF_UP));
+    Assert.assertEquals(new BigDecimal("52241911925"), Simm.calculateTotal(Arrays.asList(CNQ1, CNQ2, CNQ3, CNQ4, CNQ5, CNQ6, CNQ7, CNQ8), Arrays.asList(CQ16), EMPTY_FACTORS, EMPTY_NOTIONALS, ZERO_FIXED, FxRate.USD, HoldingPeriod.TenDay).setScale(0, RoundingMode.HALF_UP));
   }
 
   @Test // tested: Risk Corr (CQ to CNQ)
   public void testRisk3() {
     List<Sensitivity> s = Arrays.asList(CQ1, CQ2, CQ3, CQ4, CQ5, CQ6, CQ7, CQ8, CQ9, CQ10, CQ11, CQ12, CQ13, CQ14, CQ15, BC1, BC2, BC3, BC4, CNQ1, CNQ2, CNQ3, CNQ4, CNQ5, CNQ6, CNQ7, CNQ8);
-    Assert.assertEquals(new BigDecimal("53891826164"), Simm.calculateTotal(s, Arrays.asList(CQ16), EMPTY_FACTORS, EMPTY_NOTIONALS, ZERO_FIXED, FxRate.USD).setScale(0, RoundingMode.HALF_UP));
+    Assert.assertEquals(new BigDecimal("53891826164"), Simm.calculateTotal(s, Arrays.asList(CQ16), EMPTY_FACTORS, EMPTY_NOTIONALS, ZERO_FIXED, FxRate.USD, HoldingPeriod.TenDay).setScale(0, RoundingMode.HALF_UP));
   }
 
   @Test // tested: risk weight
   public void testCM1() {
-    Assert.assertEquals(new BigDecimal("570000000"), Simm.calculateStandard(Arrays.asList(CM1), FxRate.USD).setScale(0, RoundingMode.HALF_UP));
+    Assert.assertEquals(new BigDecimal("570000000"), Simm.calculateStandard(Arrays.asList(CM1), FxRate.USD, HoldingPeriod.TenDay).setScale(0, RoundingMode.HALF_UP));
   }
 
   @Test // tested: risk weight
   public void testCM2() {
-    Assert.assertEquals(new BigDecimal("2550000000"), Simm.calculateStandard(Arrays.asList(CM3), FxRate.USD).setScale(0, RoundingMode.HALF_UP));
+    Assert.assertEquals(new BigDecimal("2550000000"), Simm.calculateStandard(Arrays.asList(CM3), FxRate.USD, HoldingPeriod.TenDay).setScale(0, RoundingMode.HALF_UP));
   }
 
   @Test // tested: risk weight
   public void testCM3() {
-    Assert.assertEquals(new BigDecimal("1430000000"), Simm.calculateStandard(Arrays.asList(CM6), FxRate.USD).setScale(0, RoundingMode.HALF_UP));
+    Assert.assertEquals(new BigDecimal("1430000000"), Simm.calculateStandard(Arrays.asList(CM6), FxRate.USD, HoldingPeriod.TenDay).setScale(0, RoundingMode.HALF_UP));
   }
 
   @Test // tested: risk weight, CR (above threshold)
   public void testCM4() {
-    Assert.assertEquals(new BigDecimal("49033642297"), Simm.calculateStandard(Arrays.asList(CM8), FxRate.USD).setScale(0, RoundingMode.HALF_UP));
+    Assert.assertEquals(new BigDecimal("49033642297"), Simm.calculateStandard(Arrays.asList(CM8), FxRate.USD, HoldingPeriod.TenDay).setScale(0, RoundingMode.HALF_UP));
   }
 
   @Test // tested: risk weight
   public void testCM5() {
-    Assert.assertEquals(new BigDecimal("350000000"), Simm.calculateStandard(Arrays.asList(CM10), FxRate.USD).setScale(0, RoundingMode.HALF_UP));
+    Assert.assertEquals(new BigDecimal("350000000"), Simm.calculateStandard(Arrays.asList(CM10), FxRate.USD, HoldingPeriod.TenDay).setScale(0, RoundingMode.HALF_UP));
   }
 
   @Test // tested: risk weight
   public void testCM6() {
-    Assert.assertEquals(new BigDecimal("120000000"), Simm.calculateStandard(Arrays.asList(CM11), FxRate.USD).setScale(0, RoundingMode.HALF_UP));
+    Assert.assertEquals(new BigDecimal("120000000"), Simm.calculateStandard(Arrays.asList(CM11), FxRate.USD, HoldingPeriod.TenDay).setScale(0, RoundingMode.HALF_UP));
   }
 
   @Test // tested: intra-bucket (negtive correlation)
   public void testCM7() {
-    Assert.assertEquals(new BigDecimal("966948809"), Simm.calculateStandard(Arrays.asList(CM1, CM2), FxRate.USD).setScale(0, RoundingMode.HALF_UP));
+    Assert.assertEquals(new BigDecimal("966948809"), Simm.calculateStandard(Arrays.asList(CM1, CM2), FxRate.USD, HoldingPeriod.TenDay).setScale(0, RoundingMode.HALF_UP));
   }
 
   @Test // tested: intra-bucket (positive correlation)
   public void testCM8() {
-    Assert.assertEquals(new BigDecimal("2310000000"), Simm.calculateStandard(Arrays.asList(CM6, CM7), FxRate.USD).setScale(0, RoundingMode.HALF_UP));
+    Assert.assertEquals(new BigDecimal("2310000000"), Simm.calculateStandard(Arrays.asList(CM6, CM7), FxRate.USD, HoldingPeriod.TenDay).setScale(0, RoundingMode.HALF_UP));
   }
 
   @Test // tested: intra-bucket (multiple)
   public void testCM9() {
-    Assert.assertEquals(new BigDecimal("4816133304"), Simm.calculateStandard(Arrays.asList(CM3, CM4, CM5), FxRate.USD).setScale(0, RoundingMode.HALF_UP));
+    Assert.assertEquals(new BigDecimal("4816133304"), Simm.calculateStandard(Arrays.asList(CM3, CM4, CM5), FxRate.USD, HoldingPeriod.TenDay).setScale(0, RoundingMode.HALF_UP));
   }
 
   @Test // tested: intra-bucket, CR (no netting for CM)
   public void testCM10() {
-    Assert.assertEquals(new BigDecimal("49085079199"), Simm.calculateStandard(Arrays.asList(CM8, CM9), FxRate.USD).setScale(0, RoundingMode.HALF_UP));
+    Assert.assertEquals(new BigDecimal("49085079199"), Simm.calculateStandard(Arrays.asList(CM8, CM9), FxRate.USD, HoldingPeriod.TenDay).setScale(0, RoundingMode.HALF_UP));
   }
 
   @Test // tested: inter-bucket
   public void testCM11() {
-    Assert.assertEquals(new BigDecimal("359638708"), Simm.calculateStandard(Arrays.asList(CM10, CM11), FxRate.USD).setScale(0, RoundingMode.HALF_UP));
+    Assert.assertEquals(new BigDecimal("359638708"), Simm.calculateStandard(Arrays.asList(CM10, CM11), FxRate.USD, HoldingPeriod.TenDay).setScale(0, RoundingMode.HALF_UP));
   }
 
   @Test // tested: inter-bucket (multiple)
   public void testCM12() {
-    Assert.assertEquals(new BigDecimal("49717717006"), Simm.calculateStandard(Arrays.asList(CM1, CM2, CM3, CM4, CM5, CM6, CM7, CM8, CM9, CM10, CM11), FxRate.USD).setScale(0, RoundingMode.HALF_UP));
+    Assert.assertEquals(new BigDecimal("49717717006"), Simm.calculateStandard(Arrays.asList(CM1, CM2, CM3, CM4, CM5, CM6, CM7, CM8, CM9, CM10, CM11), FxRate.USD, HoldingPeriod.TenDay).setScale(0, RoundingMode.HALF_UP));
   }
 
   @Test // tested: product multiplier
   public void testCM13() {
-    Assert.assertEquals(new BigDecimal("53446545781"), Simm.calculateTotal(Arrays.asList(CM1, CM2, CM3, CM4, CM5, CM6, CM7, CM8, CM9, CM10, CM11), Arrays.asList(CM12), EMPTY_FACTORS, EMPTY_NOTIONALS, ZERO_FIXED, FxRate.USD).setScale(0, RoundingMode.HALF_UP));
+    Assert.assertEquals(new BigDecimal("53446545781"), Simm.calculateTotal(Arrays.asList(CM1, CM2, CM3, CM4, CM5, CM6, CM7, CM8, CM9, CM10, CM11), Arrays.asList(CM12), EMPTY_FACTORS, EMPTY_NOTIONALS, ZERO_FIXED, FxRate.USD, HoldingPeriod.TenDay).setScale(0, RoundingMode.HALF_UP));
   }
 
   @Test // tested: All delta
   public void testRisk4() {
     List<Sensitivity> s = Arrays.asList(CM1, CM2, CM3, CM4, CM5, CM6, CM7, CM8, CM9, CM10, CM11, CQ1, CQ2, CQ3, CQ4, CQ5, CQ6, CQ7, CQ8, CQ9, CQ10, CQ11, CQ12, CQ13, CQ14, CQ15, BC1, BC2, BC3, BC4, CNQ1, CNQ2, CNQ3, CNQ4, CNQ5, CNQ6, CNQ7, CNQ8, EQ1, EQ2, EQ3, EQ4, EQ5, EQ6, EQ7, EQ8, EQ9, EQ10, EQ11, IR1, IR2, IR3, IR4, IR5, IR6, IR7, IR8, IR9, FX1, FX2, FX3, FX4);
-    Assert.assertEquals(new BigDecimal("157948213493"), Simm.calculateTotal(s, Arrays.asList(CM12, IR10, EQ12, CQ16), EMPTY_FACTORS, EMPTY_NOTIONALS, ZERO_FIXED, FxRate.USD).setScale(0, RoundingMode.HALF_UP));
+    Assert.assertEquals(new BigDecimal("157948213493"), Simm.calculateTotal(s, Arrays.asList(CM12, IR10, EQ12, CQ16), EMPTY_FACTORS, EMPTY_NOTIONALS, ZERO_FIXED, FxRate.USD, HoldingPeriod.TenDay).setScale(0, RoundingMode.HALF_UP));
   }
 
 }

--- a/simm/src/test/java/com/acadiasoft/im/simm/engine/AcadiaGlobalUnitTestV2_0.java
+++ b/simm/src/test/java/com/acadiasoft/im/simm/engine/AcadiaGlobalUnitTestV2_0.java
@@ -27,6 +27,7 @@ import com.acadiasoft.im.simm.model.AddOnNotional;
 import com.acadiasoft.im.simm.model.AddOnNotionalFactor;
 import com.acadiasoft.im.simm.model.ProductMultiplier;
 import com.acadiasoft.im.simm.model.Sensitivity;
+import com.acadiasoft.im.simm.model.param.HoldingPeriod;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -51,7 +52,22 @@ public class AcadiaGlobalUnitTestV2_0 extends AbstractAcadiaUnitTestV2_0 {
     notional.addAll(Arrays.asList(AN9));
     List<ProductMultiplier> multipliers = Arrays.asList(CM12, IR10, EQ12, CQ16);
     List<Sensitivity> s = Arrays.asList(CM1, CM2, CM3, CM4, CM5, CM6, CM7, CM8, CM9, CM10, CM11, CQ1, CQ2, CQ3, CQ4, CQ5, CQ6, CQ7, CQ8, CQ9, CQ10, CQ11, CQ12, CQ13, CQ14, CQ15, BC1, BC2, BC3, BC4, CNQ1, CNQ2, CNQ3, CNQ4, CNQ5, CNQ6, CNQ7, CNQ8, EQ1, EQ2, EQ3, EQ4, EQ5, EQ6, EQ7, EQ8, EQ9, EQ10, EQ11, IR1, IR2, IR3, IR4, IR5, IR6, IR7, IR8, IR9, FX1, FX2, FX3, FX4, CMV1, CMV2, CMV3, CMV4, CMV5, CMV6, CQV1, CQV2, CQV3, CQV4, CQV5, CNQV1, CNQV2, CNQV3, CNQV4, CNQV5, EQV1, EQV2, EQV3, EQV4, EQV5, EQV6, EQV7, EQV8, EQV9, EQV10, FXV1, FXV2, FXV3, FXV4, FXV5, IRV1, IRV2, IRV3, IRV4, IRV5, IRV6, IRV7);
-    Assert.assertEquals(new BigDecimal("190371821528"), Simm.calculateTotal(s, multipliers, factors, notional, Arrays.asList(AN10, AN11), FxRate.USD).setScale(0, RoundingMode.HALF_UP));
+    Assert.assertEquals(new BigDecimal("190371821528"), Simm.calculateTotal(s, multipliers, factors, notional, Arrays.asList(AN10, AN11), FxRate.USD, HoldingPeriod.TenDay).setScale(0, RoundingMode.HALF_UP));
   }
 
+  @Test
+  public void testCRQ_1Day()
+  {
+    List<Sensitivity> s = Arrays.asList(S_CRQ_1, S_CRQ_1, S_CRQ_2);
+    BigDecimal actual = Simm.calculateTotal(
+            s,
+            Arrays.asList(),
+            EMPTY_FACTORS,
+            EMPTY_NOTIONALS,
+            ZERO_FIXED,
+            FxRate.USD,
+            HoldingPeriod.OneDay)
+            .setScale(0, RoundingMode.HALF_UP);
+    Assert.assertEquals(new BigDecimal("24979039"), actual);
+  }
 }

--- a/simm/src/test/java/com/acadiasoft/im/simm/engine/AcadiaVegaUnitTestV2_0.java
+++ b/simm/src/test/java/com/acadiasoft/im/simm/engine/AcadiaVegaUnitTestV2_0.java
@@ -24,6 +24,7 @@ package com.acadiasoft.im.simm.engine;
 
 import com.acadiasoft.im.base.fx.FxRate;
 import com.acadiasoft.im.simm.model.Sensitivity;
+import com.acadiasoft.im.simm.model.param.HoldingPeriod;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -40,260 +41,260 @@ public class AcadiaVegaUnitTestV2_0 extends AbstractAcadiaUnitTestV2_0 {
 
   @Test // tested: vega weighting, Curvature > 0
   public void testIRV1() {
-    Assert.assertEquals(new BigDecimal("296817050"), Simm.calculateStandard(Arrays.asList(IRV1), FxRate.USD).setScale(0, RoundingMode.HALF_UP));
+    Assert.assertEquals(new BigDecimal("296817050"), Simm.calculateStandard(Arrays.asList(IRV1), FxRate.USD, HoldingPeriod.TenDay).setScale(0, RoundingMode.HALF_UP));
   }
 
   @Test // tested: vega weighting, Curvature < 0
   public void testIRV2() {
-    Assert.assertEquals(new BigDecimal("48000000"), Simm.calculateStandard(Arrays.asList(IRV2), FxRate.USD).setScale(0, RoundingMode.HALF_UP));
+    Assert.assertEquals(new BigDecimal("48000000"), Simm.calculateStandard(Arrays.asList(IRV2), FxRate.USD, HoldingPeriod.TenDay).setScale(0, RoundingMode.HALF_UP));
   }
 
   @Test // tested: No netting in IRVol
   public void testIRV3() {
-    Assert.assertEquals(new BigDecimal("14248000000"), Simm.calculateStandard(Arrays.asList(IR1, IRV2), FxRate.USD).setScale(0, RoundingMode.HALF_UP));
+    Assert.assertEquals(new BigDecimal("14248000000"), Simm.calculateStandard(Arrays.asList(IR1, IRV2), FxRate.USD, HoldingPeriod.TenDay).setScale(0, RoundingMode.HALF_UP));
   }
 
   @Test // tested: vega weighting (inflation), Curvature > 0
   public void testIRV4() {
-    Assert.assertEquals(new BigDecimal("176551066"), Simm.calculateStandard(Arrays.asList(IRV7), FxRate.USD).setScale(0, RoundingMode.HALF_UP));
+    Assert.assertEquals(new BigDecimal("176551066"), Simm.calculateStandard(Arrays.asList(IRV7), FxRate.USD, HoldingPeriod.TenDay).setScale(0, RoundingMode.HALF_UP));
   }
 
   @Test // tested: netting for InflationVol
   public void testIRV5() {
-    Assert.assertEquals(new BigDecimal("56000000"), Simm.calculateStandard(Arrays.asList(IRV5, IRV6), FxRate.USD).setScale(0, RoundingMode.HALF_UP));
+    Assert.assertEquals(new BigDecimal("56000000"), Simm.calculateStandard(Arrays.asList(IRV5, IRV6), FxRate.USD, HoldingPeriod.TenDay).setScale(0, RoundingMode.HALF_UP));
   }
 
   @Test // tested: vol weight in CR
   public void testIRV6() {
-    Assert.assertEquals(new BigDecimal("22028345"), Simm.calculateStandard(Arrays.asList(IRV3, IRV4), FxRate.USD).setScale(0, RoundingMode.HALF_UP));
+    Assert.assertEquals(new BigDecimal("22028345"), Simm.calculateStandard(Arrays.asList(IRV3, IRV4), FxRate.USD, HoldingPeriod.TenDay).setScale(0, RoundingMode.HALF_UP));
   }
 
   @Test // tested: intra-bucket
   public void testIRV7() {
-    Assert.assertEquals(new BigDecimal("387969168"), Simm.calculateStandard(Arrays.asList(IRV1, IRV2, IRV7), FxRate.USD).setScale(0, RoundingMode.HALF_UP));
+    Assert.assertEquals(new BigDecimal("387969168"), Simm.calculateStandard(Arrays.asList(IRV1, IRV2, IRV7), FxRate.USD, HoldingPeriod.TenDay).setScale(0, RoundingMode.HALF_UP));
   }
 
   @Test // tested: multiple buckets
   public void testIRV8() {
-    Assert.assertEquals(new BigDecimal("483003521"), Simm.calculateStandard(Arrays.asList(IRV1, IRV2, IRV3, IRV4, IRV5, IRV6, IRV7), FxRate.USD).setScale(0, RoundingMode.HALF_UP));
+    Assert.assertEquals(new BigDecimal("483003521"), Simm.calculateStandard(Arrays.asList(IRV1, IRV2, IRV3, IRV4, IRV5, IRV6, IRV7), FxRate.USD, HoldingPeriod.TenDay).setScale(0, RoundingMode.HALF_UP));
   }
 
   @Test // tested: vega weighting, Curvature > 0
   public void testFXV1() {
-    Assert.assertEquals(new BigDecimal("197113249"), Simm.calculateStandard(Arrays.asList(FXV1), FxRate.USD).setScale(0, RoundingMode.HALF_UP));
+    Assert.assertEquals(new BigDecimal("197113249"), Simm.calculateStandard(Arrays.asList(FXV1), FxRate.USD, HoldingPeriod.TenDay).setScale(0, RoundingMode.HALF_UP));
   }
 
   @Test // tested: vega weighting, Curvature < 0
   public void testFXV2() {
-    Assert.assertEquals(new BigDecimal("84002960"), Simm.calculateStandard(Arrays.asList(FXV5), FxRate.USD).setScale(0, RoundingMode.HALF_UP));
+    Assert.assertEquals(new BigDecimal("84002960"), Simm.calculateStandard(Arrays.asList(FXV5), FxRate.USD, HoldingPeriod.TenDay).setScale(0, RoundingMode.HALF_UP));
   }
 
   @Test // tested: netting over tenors, order or currency pair doesn't matter, CR (vol weighted values in CR)
   public void testFXV3() {
-    Assert.assertEquals(new BigDecimal("546819143"), Simm.calculateStandard(Arrays.asList(FXV1, FXV2), FxRate.USD).setScale(0, RoundingMode.HALF_UP));
+    Assert.assertEquals(new BigDecimal("546819143"), Simm.calculateStandard(Arrays.asList(FXV1, FXV2), FxRate.USD, HoldingPeriod.TenDay).setScale(0, RoundingMode.HALF_UP));
   }
 
   @Test // tested: netting over tenors, order or currency pair doesn't matter, CR (netting to be below threshold)
   public void testFXV4() {
-    Assert.assertEquals(new BigDecimal("199496275"), Simm.calculateStandard(Arrays.asList(FXV1, FXV2, FXV3), FxRate.USD).setScale(0, RoundingMode.HALF_UP));
+    Assert.assertEquals(new BigDecimal("199496275"), Simm.calculateStandard(Arrays.asList(FXV1, FXV2, FXV3), FxRate.USD, HoldingPeriod.TenDay).setScale(0, RoundingMode.HALF_UP));
   }
 
   @Test // multiple, CR (no netting across risk factors)
   public void testFXV5() {
-    Assert.assertEquals(new BigDecimal("466370454"), Simm.calculateStandard(Arrays.asList(FXV1, FXV2, FXV3, FXV4, FXV5), FxRate.USD).setScale(0, RoundingMode.HALF_UP));
+    Assert.assertEquals(new BigDecimal("466370454"), Simm.calculateStandard(Arrays.asList(FXV1, FXV2, FXV3, FXV4, FXV5), FxRate.USD, HoldingPeriod.TenDay).setScale(0, RoundingMode.HALF_UP));
   }
 
   @Test // testing 0 value in FXV
   public void testFXV6() {
     Sensitivity zero = new Sensitivity("RatesFX", "Risk_FXVol", "USDJPY", "", "2w", "", BigDecimal.ZERO);
-    Assert.assertEquals(BigDecimal.ZERO, Simm.calculateStandard(Arrays.asList(zero), FxRate.USD).setScale(0, RoundingMode.HALF_UP));
+    Assert.assertEquals(BigDecimal.ZERO, Simm.calculateStandard(Arrays.asList(zero), FxRate.USD, HoldingPeriod.TenDay).setScale(0, RoundingMode.HALF_UP));
   }
 
   @Test // risk weight
   public void testEQV1() {
-    Assert.assertEquals(new BigDecimal("319360046"), Simm.calculateStandard(Arrays.asList(EQV1), FxRate.USD).setScale(0, RoundingMode.HALF_UP));
+    Assert.assertEquals(new BigDecimal("319360046"), Simm.calculateStandard(Arrays.asList(EQV1), FxRate.USD, HoldingPeriod.TenDay).setScale(0, RoundingMode.HALF_UP));
   }
 
   @Test // risk weight
   public void testEQV2() {
-    Assert.assertEquals(new BigDecimal("1345791692"), Simm.calculateStandard(Arrays.asList(EQV4), FxRate.USD).setScale(0, RoundingMode.HALF_UP));
+    Assert.assertEquals(new BigDecimal("1345791692"), Simm.calculateStandard(Arrays.asList(EQV4), FxRate.USD, HoldingPeriod.TenDay).setScale(0, RoundingMode.HALF_UP));
   }
 
   @Test // risk weight
   public void testEQV3() {
-    Assert.assertEquals(new BigDecimal("264329313"), Simm.calculateStandard(Arrays.asList(EQV6), FxRate.USD).setScale(0, RoundingMode.HALF_UP));
+    Assert.assertEquals(new BigDecimal("264329313"), Simm.calculateStandard(Arrays.asList(EQV6), FxRate.USD, HoldingPeriod.TenDay).setScale(0, RoundingMode.HALF_UP));
   }
 
   @Test // risk weight
   public void testEQV4() {
-    Assert.assertEquals(new BigDecimal("208036959"), Simm.calculateStandard(Arrays.asList(EQV7), FxRate.USD).setScale(0, RoundingMode.HALF_UP));
+    Assert.assertEquals(new BigDecimal("208036959"), Simm.calculateStandard(Arrays.asList(EQV7), FxRate.USD, HoldingPeriod.TenDay).setScale(0, RoundingMode.HALF_UP));
   }
 
   @Test // risk weight residual
   public void testEQV5() {
-    Assert.assertEquals(new BigDecimal("5312157001"), Simm.calculateStandard(Arrays.asList(EQV10), FxRate.USD).setScale(0, RoundingMode.HALF_UP));
+    Assert.assertEquals(new BigDecimal("5312157001"), Simm.calculateStandard(Arrays.asList(EQV10), FxRate.USD, HoldingPeriod.TenDay).setScale(0, RoundingMode.HALF_UP));
   }
 
   @Test // intra-bucket (netting)
   public void testEQV6() {
-    Assert.assertEquals(new BigDecimal("17404399"), Simm.calculateStandard(Arrays.asList(EQV1, EQV2), FxRate.USD).setScale(0, RoundingMode.HALF_UP));
+    Assert.assertEquals(new BigDecimal("17404399"), Simm.calculateStandard(Arrays.asList(EQV1, EQV2), FxRate.USD, HoldingPeriod.TenDay).setScale(0, RoundingMode.HALF_UP));
   }
 
   @Test // intra-bucket (netting), (CR)
   public void testEQV7() {
-    Assert.assertEquals(new BigDecimal("12048394168"), Simm.calculateStandard(Arrays.asList(EQV1, EQV2, EQV3), FxRate.USD).setScale(0, RoundingMode.HALF_UP));
+    Assert.assertEquals(new BigDecimal("12048394168"), Simm.calculateStandard(Arrays.asList(EQV1, EQV2, EQV3), FxRate.USD, HoldingPeriod.TenDay).setScale(0, RoundingMode.HALF_UP));
   }
 
   @Test // intra-bucket
   public void testEQV8() {
-    Assert.assertEquals(new BigDecimal("1545642629"), Simm.calculateStandard(Arrays.asList(EQV4, EQV5), FxRate.USD).setScale(0, RoundingMode.HALF_UP));
+    Assert.assertEquals(new BigDecimal("1545642629"), Simm.calculateStandard(Arrays.asList(EQV4, EQV5), FxRate.USD, HoldingPeriod.TenDay).setScale(0, RoundingMode.HALF_UP));
   }
 
   @Test // residual
   public void testEQV9() {
-    Assert.assertEquals(new BigDecimal("5678830191"), Simm.calculateStandard(Arrays.asList(EQV8, EQV9, EQV10), FxRate.USD).setScale(0, RoundingMode.HALF_UP));
+    Assert.assertEquals(new BigDecimal("5678830191"), Simm.calculateStandard(Arrays.asList(EQV8, EQV9, EQV10), FxRate.USD, HoldingPeriod.TenDay).setScale(0, RoundingMode.HALF_UP));
   }
 
   @Test // inter-bucket
   public void testEQV10() {
-    Assert.assertEquals(new BigDecimal("1582952747"), Simm.calculateStandard(Arrays.asList(EQV4, EQV5, EQV6, EQV7), FxRate.USD).setScale(0, RoundingMode.HALF_UP));
+    Assert.assertEquals(new BigDecimal("1582952747"), Simm.calculateStandard(Arrays.asList(EQV4, EQV5, EQV6, EQV7), FxRate.USD, HoldingPeriod.TenDay).setScale(0, RoundingMode.HALF_UP));
   }
 
   @Test // inter-bucket (residual)
   public void testEQV11() {
-    Assert.assertEquals(new BigDecimal("7261782938"), Simm.calculateStandard(Arrays.asList(EQV4, EQV5, EQV6, EQV7, EQV8, EQV9, EQV10), FxRate.USD).setScale(0, RoundingMode.HALF_UP));
+    Assert.assertEquals(new BigDecimal("7261782938"), Simm.calculateStandard(Arrays.asList(EQV4, EQV5, EQV6, EQV7, EQV8, EQV9, EQV10), FxRate.USD, HoldingPeriod.TenDay).setScale(0, RoundingMode.HALF_UP));
   }
 
   @Test // inter-bucket, CR
   public void testEQV12() {
-    Assert.assertEquals(new BigDecimal("18278596023"), Simm.calculateStandard(Arrays.asList(EQV1, EQV2, EQV3, EQV4, EQV5, EQV6, EQV7, EQV8, EQV9, EQV10), FxRate.USD).setScale(0, RoundingMode.HALF_UP));
+    Assert.assertEquals(new BigDecimal("18278596023"), Simm.calculateStandard(Arrays.asList(EQV1, EQV2, EQV3, EQV4, EQV5, EQV6, EQV7, EQV8, EQV9, EQV10), FxRate.USD, HoldingPeriod.TenDay).setScale(0, RoundingMode.HALF_UP));
   }
 
   @Test // risk weight (residual), negative
   public void testCNQV1() {
-    Assert.assertEquals(new BigDecimal("6210000"), Simm.calculateStandard(Arrays.asList(CNQV1), FxRate.USD).setScale(0, RoundingMode.HALF_UP));
+    Assert.assertEquals(new BigDecimal("6210000"), Simm.calculateStandard(Arrays.asList(CNQV1), FxRate.USD, HoldingPeriod.TenDay).setScale(0, RoundingMode.HALF_UP));
   }
 
   @Test // risk weight
   public void testCNQV2() {
-    Assert.assertEquals(new BigDecimal("6632694"), Simm.calculateStandard(Arrays.asList(CNQV6), FxRate.USD).setScale(0, RoundingMode.HALF_UP));
+    Assert.assertEquals(new BigDecimal("6632694"), Simm.calculateStandard(Arrays.asList(CNQV6), FxRate.USD, HoldingPeriod.TenDay).setScale(0, RoundingMode.HALF_UP));
   }
 
   @Test // risk weight
   public void testCNQV3() {
-    Assert.assertEquals(new BigDecimal("9990000"), Simm.calculateStandard(Arrays.asList(CNQV7), FxRate.USD).setScale(0, RoundingMode.HALF_UP));
+    Assert.assertEquals(new BigDecimal("9990000"), Simm.calculateStandard(Arrays.asList(CNQV7), FxRate.USD, HoldingPeriod.TenDay).setScale(0, RoundingMode.HALF_UP));
   }
 
   @Test // intra-bucket (residual), negative (No Curvature)
   public void testCNQV4() {
-    Assert.assertEquals(new BigDecimal("14170743"), Simm.calculateStandard(Arrays.asList(CNQV3, CNQV4), FxRate.USD).setScale(0, RoundingMode.HALF_UP));
+    Assert.assertEquals(new BigDecimal("14170743"), Simm.calculateStandard(Arrays.asList(CNQV3, CNQV4), FxRate.USD, HoldingPeriod.TenDay).setScale(0, RoundingMode.HALF_UP));
   }
 
   @Test // intra-bucket (residual)
   public void testCNQV5() {
-    Assert.assertEquals(new BigDecimal("13658371"), Simm.calculateStandard(Arrays.asList(CNQV1, CNQV3), FxRate.USD).setScale(0, RoundingMode.HALF_UP));
+    Assert.assertEquals(new BigDecimal("13658371"), Simm.calculateStandard(Arrays.asList(CNQV1, CNQV3), FxRate.USD, HoldingPeriod.TenDay).setScale(0, RoundingMode.HALF_UP));
   }
 
   @Test // intra-bucket (residual)
   public void testCNQV6() {
-    Assert.assertEquals(new BigDecimal("19629425"), Simm.calculateStandard(Arrays.asList(CNQV2, CNQV4), FxRate.USD).setScale(0, RoundingMode.HALF_UP));
+    Assert.assertEquals(new BigDecimal("19629425"), Simm.calculateStandard(Arrays.asList(CNQV2, CNQV4), FxRate.USD, HoldingPeriod.TenDay).setScale(0, RoundingMode.HALF_UP));
   }
 
   @Test // intra-bucket (residual)
   public void testCNQV7() {
-    Assert.assertEquals(new BigDecimal("20898727"), Simm.calculateStandard(Arrays.asList(CNQV1, CNQV2, CNQV3, CNQV4, CNQV5), FxRate.USD).setScale(0, RoundingMode.HALF_UP));
+    Assert.assertEquals(new BigDecimal("20898727"), Simm.calculateStandard(Arrays.asList(CNQV1, CNQV2, CNQV3, CNQV4, CNQV5), FxRate.USD, HoldingPeriod.TenDay).setScale(0, RoundingMode.HALF_UP));
   }
 
   @Test // risk weight (residual), negative
   public void testCQV1() {
-    Assert.assertEquals(new BigDecimal("53811725"), Simm.calculateStandard(Arrays.asList(CQV1), FxRate.USD).setScale(0, RoundingMode.HALF_UP));
+    Assert.assertEquals(new BigDecimal("53811725"), Simm.calculateStandard(Arrays.asList(CQV1), FxRate.USD, HoldingPeriod.TenDay).setScale(0, RoundingMode.HALF_UP));
   }
 
   @Test // risk weight
   public void testCQV2() {
-    Assert.assertEquals(new BigDecimal("5908978"), Simm.calculateStandard(Arrays.asList(CQV6), FxRate.USD).setScale(0, RoundingMode.HALF_UP));
+    Assert.assertEquals(new BigDecimal("5908978"), Simm.calculateStandard(Arrays.asList(CQV6), FxRate.USD, HoldingPeriod.TenDay).setScale(0, RoundingMode.HALF_UP));
   }
 
   @Test // risk weight
   public void testCQV3() {
-    Assert.assertEquals(new BigDecimal("13500000"), Simm.calculateStandard(Arrays.asList(CQV7), FxRate.USD).setScale(0, RoundingMode.HALF_UP));
+    Assert.assertEquals(new BigDecimal("13500000"), Simm.calculateStandard(Arrays.asList(CQV7), FxRate.USD, HoldingPeriod.TenDay).setScale(0, RoundingMode.HALF_UP));
   }
 
   @Test // intra-bucket (residual), negative (No Curvature)
   public void testCQV4() {
-    Assert.assertEquals(new BigDecimal("14287057"), Simm.calculateStandard(Arrays.asList(CQV3, CQV4), FxRate.USD).setScale(0, RoundingMode.HALF_UP));
+    Assert.assertEquals(new BigDecimal("14287057"), Simm.calculateStandard(Arrays.asList(CQV3, CQV4), FxRate.USD, HoldingPeriod.TenDay).setScale(0, RoundingMode.HALF_UP));
   }
 
   @Test // intra-bucket (residual)
   public void testCQV5() {
-    Assert.assertEquals(new BigDecimal("54180306"), Simm.calculateStandard(Arrays.asList(CQV1, CQV3), FxRate.USD).setScale(0, RoundingMode.HALF_UP));
+    Assert.assertEquals(new BigDecimal("54180306"), Simm.calculateStandard(Arrays.asList(CQV1, CQV3), FxRate.USD, HoldingPeriod.TenDay).setScale(0, RoundingMode.HALF_UP));
   }
 
   @Test // intra-bucket (residual)
   public void testCQV6() {
-    Assert.assertEquals(new BigDecimal("12354863"), Simm.calculateStandard(Arrays.asList(CQV2, CQV4), FxRate.USD).setScale(0, RoundingMode.HALF_UP));
+    Assert.assertEquals(new BigDecimal("12354863"), Simm.calculateStandard(Arrays.asList(CQV2, CQV4), FxRate.USD, HoldingPeriod.TenDay).setScale(0, RoundingMode.HALF_UP));
   }
 
   @Test // intra-bucket (residual)
   public void testCQV7() {
-    Assert.assertEquals(new BigDecimal("57583035"), Simm.calculateStandard(Arrays.asList(CQV1, CQV2, CQV3, CQV4, CQV5), FxRate.USD).setScale(0, RoundingMode.HALF_UP));
+    Assert.assertEquals(new BigDecimal("57583035"), Simm.calculateStandard(Arrays.asList(CQV1, CQV2, CQV3, CQV4, CQV5), FxRate.USD, HoldingPeriod.TenDay).setScale(0, RoundingMode.HALF_UP));
   }
 
   @Test // risk weight, CR
   public void testCMV1() {
-    Assert.assertEquals(new BigDecimal("5502933299"), Simm.calculateStandard(Arrays.asList(CMV1), FxRate.USD).setScale(0, RoundingMode.HALF_UP));
+    Assert.assertEquals(new BigDecimal("5502933299"), Simm.calculateStandard(Arrays.asList(CMV1), FxRate.USD, HoldingPeriod.TenDay).setScale(0, RoundingMode.HALF_UP));
   }
 
   @Test // risk weight, CR
   public void testCMV2() {
-    Assert.assertEquals(new BigDecimal("193811031"), Simm.calculateStandard(Arrays.asList(CMV4), FxRate.USD).setScale(0, RoundingMode.HALF_UP));
+    Assert.assertEquals(new BigDecimal("193811031"), Simm.calculateStandard(Arrays.asList(CMV4), FxRate.USD, HoldingPeriod.TenDay).setScale(0, RoundingMode.HALF_UP));
   }
 
   @Test // risk weight, negative
   public void testCMV3() {
-    Assert.assertEquals(new BigDecimal("131560191"), Simm.calculateStandard(Arrays.asList(CMV6), FxRate.USD).setScale(0, RoundingMode.HALF_UP));
+    Assert.assertEquals(new BigDecimal("131560191"), Simm.calculateStandard(Arrays.asList(CMV6), FxRate.USD, HoldingPeriod.TenDay).setScale(0, RoundingMode.HALF_UP));
   }
 
   @Test // intra-bucket (netting)
   public void testCMV4() {
-    Assert.assertEquals(new BigDecimal("5087508748"), Simm.calculateStandard(Arrays.asList(CMV1, CMV2), FxRate.USD).setScale(0, RoundingMode.HALF_UP));
+    Assert.assertEquals(new BigDecimal("5087508748"), Simm.calculateStandard(Arrays.asList(CMV1, CMV2), FxRate.USD, HoldingPeriod.TenDay).setScale(0, RoundingMode.HALF_UP));
   }
 
   @Test // intra-bucket (netting/only netting on same qualifier)
   public void testCMV5() {
-    Assert.assertEquals(new BigDecimal("5296449605"), Simm.calculateStandard(Arrays.asList(CMV1, CMV2, CMV3), FxRate.USD).setScale(0, RoundingMode.HALF_UP));
+    Assert.assertEquals(new BigDecimal("5296449605"), Simm.calculateStandard(Arrays.asList(CMV1, CMV2, CMV3), FxRate.USD, HoldingPeriod.TenDay).setScale(0, RoundingMode.HALF_UP));
   }
 
   @Test // intra-bucket (netting)
   public void testCMV6() {
-    Assert.assertEquals(new BigDecimal("10067405222"), Simm.calculateStandard(Arrays.asList(CMV4, CMV5), FxRate.USD).setScale(0, RoundingMode.HALF_UP));
+    Assert.assertEquals(new BigDecimal("10067405222"), Simm.calculateStandard(Arrays.asList(CMV4, CMV5), FxRate.USD, HoldingPeriod.TenDay).setScale(0, RoundingMode.HALF_UP));
   }
 
   @Test // inter-bucket
   public void testCMV7() {
-    Assert.assertEquals(new BigDecimal("11968925376"), Simm.calculateStandard(Arrays.asList(CMV1, CMV2, CMV4, CMV5), FxRate.USD).setScale(0, RoundingMode.HALF_UP));
+    Assert.assertEquals(new BigDecimal("11968925376"), Simm.calculateStandard(Arrays.asList(CMV1, CMV2, CMV4, CMV5), FxRate.USD, HoldingPeriod.TenDay).setScale(0, RoundingMode.HALF_UP));
   }
 
   @Test // inter-bucket
   public void testCMV8() {
-    Assert.assertEquals(new BigDecimal("12012068652"), Simm.calculateStandard(Arrays.asList(CMV1, CMV2, CMV3, CMV4, CMV5, CMV6), FxRate.USD).setScale(0, RoundingMode.HALF_UP));
+    Assert.assertEquals(new BigDecimal("12012068652"), Simm.calculateStandard(Arrays.asList(CMV1, CMV2, CMV3, CMV4, CMV5, CMV6), FxRate.USD, HoldingPeriod.TenDay).setScale(0, RoundingMode.HALF_UP));
   }
 
   @Test // multiple product classes
   public void testRisk1() {
     List<Sensitivity> s = Arrays.asList(CMV1, CMV2, CMV3, CMV4, CMV5, CMV6, CQV1, CQV2, CQV3, CQV4, CQV5, CNQV1, CNQV2, CNQV3, CNQV4, CNQV5, EQV1, EQV2, EQV3, EQV4, EQV5, EQV6, EQV7, EQV8, EQV9, EQV10, FXV1, FXV2, FXV3, FXV4, FXV5, IRV1, IRV2, IRV3, IRV4, IRV5, IRV6, IRV7);
-    Assert.assertEquals(new BigDecimal("31103027174"), Simm.calculateStandard(s, FxRate.USD).setScale(0, RoundingMode.HALF_UP));
+    Assert.assertEquals(new BigDecimal("31103027174"), Simm.calculateStandard(s, FxRate.USD, HoldingPeriod.TenDay).setScale(0, RoundingMode.HALF_UP));
   }
 
   @Test
   public void testInflationVolListInverted() {
     List<Sensitivity> sensitivities = inflationVolList.stream().map(s -> new Sensitivity(s.getProductClass(), s.getRiskType(), s.getQualifier(), s.getBucket(), s.getLabel1(), s.getLabel2(), s.getAmount().negate())).collect(Collectors.toList());
-    Assert.assertEquals(new BigDecimal("2356664"), Simm.calculateStandard(sensitivities, FxRate.USD).setScale(0, RoundingMode.HALF_UP));
+    Assert.assertEquals(new BigDecimal("2356664"), Simm.calculateStandard(sensitivities, FxRate.USD, HoldingPeriod.TenDay).setScale(0, RoundingMode.HALF_UP));
   }
 
   @Test
   public void testInflationVolList() {
-    Assert.assertEquals(new BigDecimal("114411.06"), Simm.calculateStandard(inflationVolList, FxRate.USD).setScale(2, RoundingMode.HALF_UP));
+    Assert.assertEquals(new BigDecimal("114411.06"), Simm.calculateStandard(inflationVolList, FxRate.USD, HoldingPeriod.TenDay).setScale(2, RoundingMode.HALF_UP));
   }
 
 }


### PR DESCRIPTION
This PR adds the ability to calculate IM with a 1-day horizon. All top-level methods such as calculateStandard, calculateAdditional and calculateTotal have now got an additional parameter called holdingPeriod that can be either TenDay or OneDay.

@colinmyles